### PR TITLE
Reintroduce case management

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,18 @@ Use the **Login** link to enter the admin password and create new posts. The
 default password can be set with the `TRUCKSOFT_ADMIN_PASSWORD` environment
 variable. The host and port may be customized with `TRUCKSOFT_HOST` and
 
+## Case Management
+
+Logged in admins can create structured cases using configurable templates.
+Use the **Cases** link in the navigation bar to view existing cases or start a
+new one. Case templates define the available fields and can be managed from the
+Templates page. Template definitions are stored in the database and support
+basic field dependencies using custom data tables.
+
+### Browser Automation
+
+The `client_tools` folder contains a small Selenium script for automatically
+creating cases. Download the Microsoft Edge WebDriver and place the binary in
+`client_tools/msedgedriver.exe`. Then run `python client_tools/case_creator.py`
+to login and submit a case based on a template. Selenium and related packages
+can be installed with `pip install selenium`.

--- a/app.py
+++ b/app.py
@@ -17,6 +17,10 @@ CLIENT_SERVICE_QUEUE = {}
 from account_routes import account_bp
 app.register_blueprint(account_bp)
 
+# Register case management blueprint
+from case_routes import cases_bp
+app.register_blueprint(cases_bp)
+
 # Initialize database on startup
 try:
     from database_init import init_database

--- a/case_routes.py
+++ b/case_routes.py
@@ -1,0 +1,145 @@
+from flask import Blueprint, render_template, request, redirect, url_for, session, flash
+import json
+from datetime import datetime
+
+try:
+    from db_utils import (
+        create_case_template, get_all_case_templates, get_case_template,
+        update_case_template, delete_case_template,
+        create_case, get_all_cases, get_case, update_case, delete_case,
+        get_custom_table_related_data
+    )
+except Exception as e:
+    print(f"Error importing db_utils: {e}")
+
+cases_bp = Blueprint('cases', __name__)
+
+
+def admin_required(func):
+    def wrapper(*args, **kwargs):
+        if not session.get('logged_in'):
+            return redirect(url_for('login'))
+        return func(*args, **kwargs)
+    wrapper.__name__ = func.__name__
+    return wrapper
+
+
+@cases_bp.route('/cases')
+@admin_required
+def case_list():
+    cases = get_all_cases()
+    templates = {t['id']: t['name'] for t in get_all_case_templates()}
+    return render_template('cases.html', cases=cases, templates=templates)
+
+
+@cases_bp.route('/cases/new', methods=['GET', 'POST'])
+@admin_required
+def new_case():
+    templates = get_all_case_templates()
+    if not templates:
+        flash('No case templates available. Create one first.', 'warning')
+        return redirect(url_for('cases.manage_templates'))
+
+    if request.method == 'POST':
+        template_id = int(request.form.get('template_id'))
+        data = {}
+        template = get_case_template(template_id)
+        if template:
+            fields = json.loads(template['fields_json'])
+            for field in fields:
+                fid = field.get('id')
+                if not fid:
+                    continue
+                value = request.form.get(fid)
+                data[fid] = value
+            case_id = create_case(template_id, json.dumps(data), session.get('username','admin'))
+            if case_id:
+                flash('Case created', 'success')
+                return redirect(url_for('cases.case_list'))
+            flash('Failed to create case', 'danger')
+    return render_template('case_form.html', templates=templates)
+
+
+@cases_bp.route('/cases/<int:case_id>/edit', methods=['GET', 'POST'])
+@admin_required
+def edit_case(case_id):
+    case = get_case(case_id)
+    if not case:
+        return redirect(url_for('cases.case_list'))
+    template = get_case_template(case['template_id'])
+    if not template:
+        flash('Template not found', 'danger')
+        return redirect(url_for('cases.case_list'))
+    fields = json.loads(template['fields_json'])
+    data = json.loads(case['data_json']) if case['data_json'] else {}
+    if request.method == 'POST':
+        for field in fields:
+            fid = field.get('id')
+            if fid:
+                data[fid] = request.form.get(fid)
+        if update_case(case_id, json.dumps(data)):
+            flash('Case updated', 'success')
+            return redirect(url_for('cases.case_list'))
+        flash('Failed to update case', 'danger')
+    return render_template('case_form.html', case=case, template=template, fields=fields, data=data)
+
+
+@cases_bp.route('/cases/<int:case_id>/delete', methods=['POST'])
+@admin_required
+def delete_case_route(case_id):
+    delete_case(case_id)
+    return redirect(url_for('cases.case_list'))
+
+
+@cases_bp.route('/case-templates', methods=['GET', 'POST'])
+@admin_required
+def manage_templates():
+    templates = get_all_case_templates()
+    if request.method == 'POST':
+        name = request.form.get('name','').strip()
+        description = request.form.get('description','').strip()
+        fields_json = request.form.get('fields_json','[]')
+        if name and fields_json:
+            if create_case_template(name, description, fields_json, session.get('username','admin')):
+                flash('Template created', 'success')
+                return redirect(url_for('cases.manage_templates'))
+            flash('Failed to create template','danger')
+    return render_template('case_templates.html', templates=templates)
+
+
+@cases_bp.route('/case-templates/<int:template_id>/edit', methods=['GET', 'POST'])
+@admin_required
+def edit_template(template_id):
+    template = get_case_template(template_id)
+    if not template:
+        return redirect(url_for('cases.manage_templates'))
+    if request.method == 'POST':
+        name = request.form.get('name','').strip()
+        description = request.form.get('description','').strip()
+        fields_json = request.form.get('fields_json','[]')
+        if update_case_template(template_id, name, description, fields_json):
+            flash('Template updated', 'success')
+            return redirect(url_for('cases.manage_templates'))
+        flash('Failed to update template','danger')
+    return render_template('case_templates.html', templates=[template], edit=True)
+
+
+@cases_bp.route('/case-templates/<int:template_id>/delete', methods=['POST'])
+@admin_required
+def delete_template(template_id):
+    delete_case_template(template_id)
+    return redirect(url_for('cases.manage_templates'))
+
+
+# API endpoint for dependent fields
+@cases_bp.route('/api/case/related-data/<table_name>', methods=['POST'])
+@admin_required
+def case_related_data(table_name):
+    payload = request.json or {}
+    column = payload.get('match_column')
+    value = payload.get('value')
+    return_columns = payload.get('return_columns', [])
+    data = get_custom_table_related_data(table_name, column, value, return_columns)
+    if data:
+        return {'success': True, 'data': data}
+    return {'success': False}

--- a/client_tools/case_creator.py
+++ b/client_tools/case_creator.py
@@ -1,0 +1,49 @@
+"""Simple Selenium automation for creating a case."""
+from selenium import webdriver
+from selenium.webdriver.edge.service import Service
+from selenium.webdriver.edge.options import Options
+from selenium.webdriver.common.by import By
+import time
+import json
+import os
+
+SERVER_URL = "http://localhost:5000"
+USERNAME = "admin"
+PASSWORD = os.environ.get("TRUCKSOFT_ADMIN_PASSWORD", "secret")
+
+TEMPLATE_NAME = "Default"
+
+def main():
+    service = Service(os.path.join(os.path.dirname(__file__), "msedgedriver.exe"))
+    options = Options()
+    options.add_argument("--headless")
+    driver = webdriver.Edge(service=service, options=options)
+
+    driver.get(f"{SERVER_URL}/login")
+    driver.find_element(By.NAME, "username").send_keys(USERNAME)
+    driver.find_element(By.NAME, "password").send_keys(PASSWORD)
+    driver.find_element(By.CSS_SELECTOR, "button[type=submit]").click()
+    time.sleep(1)
+
+    driver.get(f"{SERVER_URL}/cases/new")
+    select = driver.find_element(By.NAME, "template_id")
+    for option in select.find_elements(By.TAG_NAME, "option"):
+        if option.text.strip() == TEMPLATE_NAME:
+            option.click()
+            break
+    driver.find_element(By.CSS_SELECTOR, "button.btn-primary").click()
+    time.sleep(1)
+
+    # Fill fields with dummy data
+    inputs = driver.find_elements(By.CSS_SELECTOR, "#caseForm input")
+    for inp in inputs:
+        inp.clear()
+        inp.send_keys("test")
+
+    driver.find_element(By.CSS_SELECTOR, "#caseForm button").click()
+    time.sleep(1)
+    driver.quit()
+    print("Case submitted")
+
+if __name__ == "__main__":
+    main()

--- a/database_init.py
+++ b/database_init.py
@@ -73,6 +73,32 @@ def init_database():
                 UNIQUE(username, tool_id)
             )
         ''')
+
+        # Create case templates table
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS case_templates (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL,
+                description TEXT,
+                fields_json TEXT NOT NULL,
+                created_at TEXT,
+                updated_at TEXT,
+                created_by TEXT
+            )
+        ''')
+
+        # Create cases table
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS cases (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                template_id INTEGER NOT NULL,
+                data_json TEXT NOT NULL,
+                created_at TEXT,
+                updated_at TEXT,
+                created_by TEXT,
+                FOREIGN KEY(template_id) REFERENCES case_templates(id)
+            )
+        ''')
         
         conn.commit()
         conn.close()

--- a/db_utils.py
+++ b/db_utils.py
@@ -804,3 +804,195 @@ def toggle_user_external_tool(username, tool_id):
     except Exception as e:
         print(f"Error toggling user external tool: {e}")
         return False, f"Failed to toggle tool: {str(e)}"
+
+
+# ===================== CASE TEMPLATES =====================
+
+def create_case_template(name, description, fields_json, created_by="admin"):
+    """Create a new case template."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO case_templates (name, description, fields_json, created_at, updated_at, created_by)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    name,
+                    description,
+                    fields_json,
+                    datetime.now().isoformat(),
+                    datetime.now().isoformat(),
+                    created_by,
+                ),
+            )
+            conn.commit()
+            return cursor.lastrowid
+    except Exception as e:
+        print(f"Error creating case template: {e}")
+        return None
+
+
+def get_case_template(template_id):
+    """Retrieve a case template by ID."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT * FROM case_templates WHERE id = ?",
+                (template_id,),
+            )
+            row = cursor.fetchone()
+            return dict(row) if row else None
+    except Exception as e:
+        print(f"Error fetching case template: {e}")
+        return None
+
+
+def get_all_case_templates():
+    """Get all case templates."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT * FROM case_templates ORDER BY name"
+            )
+            return [dict(row) for row in cursor.fetchall()]
+    except Exception as e:
+        print(f"Error fetching case templates: {e}")
+        return []
+
+
+def update_case_template(template_id, name, description, fields_json):
+    """Update a case template."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                UPDATE case_templates
+                SET name = ?, description = ?, fields_json = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    name,
+                    description,
+                    fields_json,
+                    datetime.now().isoformat(),
+                    template_id,
+                ),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+    except Exception as e:
+        print(f"Error updating case template: {e}")
+        return False
+
+
+def delete_case_template(template_id):
+    """Delete a case template."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "DELETE FROM case_templates WHERE id = ?",
+                (template_id,),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+    except Exception as e:
+        print(f"Error deleting case template: {e}")
+        return False
+
+
+# ========================= CASES ==========================
+
+def create_case(template_id, data_json, created_by="admin"):
+    """Create a new case based on a template."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO cases (template_id, data_json, created_at, updated_at, created_by)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    template_id,
+                    data_json,
+                    datetime.now().isoformat(),
+                    datetime.now().isoformat(),
+                    created_by,
+                ),
+            )
+            conn.commit()
+            return cursor.lastrowid
+    except Exception as e:
+        print(f"Error creating case: {e}")
+        return None
+
+
+def get_case(case_id):
+    """Retrieve a case by ID."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT * FROM cases WHERE id = ?", (case_id,))
+            row = cursor.fetchone()
+            return dict(row) if row else None
+    except Exception as e:
+        print(f"Error fetching case: {e}")
+        return None
+
+
+def get_all_cases(limit=100):
+    """Get all cases."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT * FROM cases ORDER BY created_at DESC LIMIT ?",
+                (limit,),
+            )
+            return [dict(row) for row in cursor.fetchall()]
+    except Exception as e:
+        print(f"Error fetching cases: {e}")
+        return []
+
+
+def update_case(case_id, data_json):
+    """Update case data."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                UPDATE cases
+                SET data_json = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    data_json,
+                    datetime.now().isoformat(),
+                    case_id,
+                ),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+    except Exception as e:
+        print(f"Error updating case: {e}")
+        return False
+
+
+def delete_case(case_id):
+    """Delete a case by ID."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("DELETE FROM cases WHERE id = ?", (case_id,))
+            conn.commit()
+            return cursor.rowcount > 0
+    except Exception as e:
+        print(f"Error deleting case: {e}")
+        return False

--- a/static/js/case-form.js
+++ b/static/js/case-form.js
@@ -1,0 +1,31 @@
+// Basic dependent field handler
+function setupDependencies(relations) {
+  Object.keys(relations).forEach(fieldId => {
+    const config = relations[fieldId];
+    const el = document.querySelector(`[name="${fieldId}"]`);
+    if (el) {
+      el.addEventListener('change', () => {
+        fetch('/api/case/related-data/' + config.table, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            match_column: config.match_column,
+            value: el.value,
+            return_columns: config.return_columns
+          })
+        })
+        .then(r => r.json())
+        .then(data => {
+          if(data.success){
+            config.targets.forEach((target, idx) => {
+              const dest = document.querySelector(`[name="${target}"]`);
+              if(dest){
+                dest.value = data.data[config.return_columns[idx]] || dest.value;
+              }
+            });
+          }
+        });
+      });
+    }
+  });
+}

--- a/templates/case_form.html
+++ b/templates/case_form.html
@@ -1,0 +1,45 @@
+{% extends 'layout.html' %}
+{% block content %}
+{% if template %}
+<h2>{{ 'Edit' if case else 'New' }} Case - {{ template.name }}</h2>
+<form method="post" id="caseForm">
+  {% for field in fields %}
+  <div class="mb-3">
+    <label class="form-label">{{ field.name }}</label>
+    <input type="text" class="form-control" name="{{ field.id }}" value="{{ data.get(field.id, '') }}">
+  </div>
+  {% endfor %}
+  <button class="btn btn-primary">Save</button>
+</form>
+{% else %}
+<h2>Create Case</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Template</label>
+    <select name="template_id" class="form-select">
+      {% for t in templates %}
+      <option value="{{ t.id }}">{{ t.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <button class="btn btn-primary">Continue</button>
+</form>
+{% endif %}
+{% if template %}
+<script src="{{ url_for('static', filename='js/case-form.js') }}"></script>
+<script>
+const relations = {};
+{% for field in fields %}
+  {% if field.dependent_fields %}
+    relations["{{ field.id }}"] = {
+      table: "{{ field.data_source.table_name if field.data_source }}",
+      match_column: "{{ field.data_source.match_column if field.data_source }}",
+      return_columns: [{% for dep in field.dependent_fields %}"{{ dep.source_column }}",{% endfor %}],
+      targets: [{% for dep in field.dependent_fields %}"{{ dep.field_id }}",{% endfor %}]
+    };
+  {% endif %}
+{% endfor %}
+setupDependencies(relations);
+</script>
+{% endif %}
+{% endblock %}

--- a/templates/case_templates.html
+++ b/templates/case_templates.html
@@ -1,0 +1,36 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>Case Templates</h2>
+<div class="mb-3">
+  <form method="post">
+    <div class="row">
+      <div class="col-md-4">
+        <input type="text" name="name" class="form-control" placeholder="Template name" required>
+      </div>
+      <div class="col-md-6">
+        <input type="text" name="description" class="form-control" placeholder="Description">
+      </div>
+      <input type="hidden" name="fields_json" value="[]" id="fieldsJson">
+      <div class="col-md-2">
+        <button class="btn btn-primary" type="submit">Create</button>
+      </div>
+    </div>
+  </form>
+</div>
+<table class="table table-striped">
+  <thead><tr><th>Name</th><th>Description</th><th></th></tr></thead>
+  <tbody>
+    {% for t in templates %}
+    <tr>
+      <td>{{ t.name }}</td>
+      <td>{{ t.description }}</td>
+      <td>
+        <form method="post" action="{{ url_for('cases.delete_template', template_id=t.id) }}" onsubmit="return confirm('Delete template?');">
+          <button class="btn btn-sm btn-danger">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/cases.html
+++ b/templates/cases.html
@@ -1,0 +1,37 @@
+{% extends 'layout.html' %}
+{% block content %}
+<div class="d-flex justify-content-between mb-3">
+  <h2>Cases</h2>
+  <div>
+    <a href="{{ url_for('cases.new_case') }}" class="btn btn-primary">New Case</a>
+    <a href="{{ url_for('cases.manage_templates') }}" class="btn btn-secondary">Templates</a>
+  </div>
+</div>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Template</th>
+      <th>Created</th>
+      <th>Created By</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for case in cases %}
+    <tr>
+      <td>{{ case.id }}</td>
+      <td>{{ templates[case.template_id] }}</td>
+      <td>{{ case.created_at[:19] if case.created_at }}</td>
+      <td>{{ case.created_by }}</td>
+      <td>
+        <a href="{{ url_for('cases.edit_case', case_id=case.id) }}" class="btn btn-sm btn-primary">Edit</a>
+        <form method="post" action="{{ url_for('cases.delete_case_route', case_id=case.id) }}" style="display:inline;" onsubmit="return confirm('Delete case?');">
+          <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -22,6 +22,9 @@
             <li class="nav-item">
               <a class="nav-link" href="/">Resources</a>
             </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/cases">Cases</a>
+            </li>
             {% if session.get('logged_in') %}
             <li class="nav-item">
               <a class="nav-link" href="/new">New Post</a>

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -1,0 +1,129 @@
+import os
+import json
+import tempfile
+import os
+import os
+import json
+import tempfile
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import db_utils
+from contextlib import contextmanager
+
+
+
+
+def setup_module(module):
+    # use a temporary database for tests
+    module.db_fd, module.db_path = tempfile.mkstemp()
+
+    @contextmanager
+    def get_conn():
+        conn = db_utils.sqlite3.connect(module.db_path)
+        conn.row_factory = db_utils.sqlite3.Row
+        try:
+            yield conn
+            conn.commit()
+        finally:
+            conn.close()
+
+    db_utils.get_db_connection = get_conn
+    conn = db_utils.sqlite3.connect(module.db_path)
+    cursor = conn.cursor()
+    cursor.executescript('''
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT UNIQUE NOT NULL,
+            email TEXT UNIQUE NOT NULL,
+            password TEXT NOT NULL,
+            first_name TEXT,
+            last_name TEXT,
+            bio TEXT,
+            timezone TEXT DEFAULT 'UTC',
+            language TEXT DEFAULT 'en',
+            email_notifications INTEGER DEFAULT 1,
+            chat_notifications INTEGER DEFAULT 1,
+            newsletter INTEGER DEFAULT 0,
+            created_at TEXT,
+            updated_at TEXT,
+            last_login TEXT,
+            api_key TEXT,
+            api_enabled INTEGER DEFAULT 0,
+            external_features INTEGER DEFAULT 0
+        );
+        CREATE TABLE IF NOT EXISTS custom_tables_metadata (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            table_name TEXT UNIQUE NOT NULL,
+            display_name TEXT NOT NULL,
+            description TEXT,
+            columns_json TEXT NOT NULL,
+            created_at TEXT,
+            updated_at TEXT,
+            created_by TEXT
+        );
+        CREATE TABLE IF NOT EXISTS user_external_tools (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT NOT NULL,
+            tool_id TEXT NOT NULL,
+            name TEXT NOT NULL,
+            description TEXT,
+            icon TEXT DEFAULT 'bi bi-gear',
+            type TEXT NOT NULL CHECK (type IN ('executable', 'website', 'script')),
+            executable_path TEXT,
+            website_url TEXT,
+            parameters TEXT,
+            is_enabled INTEGER DEFAULT 1,
+            created_at TEXT,
+            updated_at TEXT,
+            UNIQUE(username, tool_id)
+        );
+        CREATE TABLE IF NOT EXISTS case_templates (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT UNIQUE NOT NULL,
+            description TEXT,
+            fields_json TEXT NOT NULL,
+            created_at TEXT,
+            updated_at TEXT,
+            created_by TEXT
+        );
+        CREATE TABLE IF NOT EXISTS cases (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            template_id INTEGER NOT NULL,
+            data_json TEXT NOT NULL,
+            created_at TEXT,
+            updated_at TEXT,
+            created_by TEXT,
+            FOREIGN KEY(template_id) REFERENCES case_templates(id)
+        );
+    ''')
+    conn.commit()
+    conn.close()
+
+
+def teardown_module(module):
+    os.close(module.db_fd)
+    os.unlink(module.db_path)
+
+
+def test_case_template_crud():
+    tid = db_utils.create_case_template('TestT', 'desc', '[]')
+    assert tid
+    tpl = db_utils.get_case_template(tid)
+    assert tpl['name'] == 'TestT'
+    assert db_utils.update_case_template(tid, 'TestT2', 'd', '[]')
+    templates = db_utils.get_all_case_templates()
+    assert any(t['name']=='TestT2' for t in templates)
+    assert db_utils.delete_case_template(tid)
+
+
+def test_case_crud():
+    tid = db_utils.create_case_template('Temp', '', '[]')
+    cid = db_utils.create_case(tid, json.dumps({'a':'b'}))
+    case = db_utils.get_case(cid)
+    assert case
+    assert db_utils.update_case(cid, json.dumps({'a':'c'}))
+    cases = db_utils.get_all_cases()
+    assert any(c['id']==cid for c in cases)
+    assert db_utils.delete_case(cid)
+    db_utils.delete_case_template(tid)
+


### PR DESCRIPTION
## Summary
- create `case_routes` blueprint for case CRUD and templates
- add case and template tables to DB initialization
- implement DB utilities for cases and templates
- add Selenium automation script in `client_tools`
- document case system and automation setup
- provide HTML pages and navigation updates for cases
- include basic JS for field dependencies
- add pytest unit tests for new DB helpers

## Testing
- `pip install flask`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b0fbffb08321a9f137a0d2d9907f