### PR TITLE
Reintroduce case management system

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,21 @@ Open `http://localhost:5000` in your browser (or the host/port you configure).
 Use the **Login** link to enter the admin password and create new posts. The
 default password can be set with the `TRUCKSOFT_ADMIN_PASSWORD` environment
 variable. The host and port may be customized with `TRUCKSOFT_HOST` and
+`TRUCKSOFT_PORT`.
 
+## Case Management
+
+Cases can be created from configurable templates. Admin users manage templates
+at `/admin/case-templates` while regular users create cases from `/cases`.
+Field options can reference custom data tables for automatic population.
+
+### Selenium Automation
+
+The `client_tools/case_creator.py` script demonstrates automated case creation
+using Selenium with Microsoft Edge WebDriver. Install the `selenium` package and
+place `msedgedriver.exe` in the `client_tools` folder. Configure your server URL
+and credentials in the script, then run:
+
+```bash
+python client_tools/case_creator.py
+```

--- a/client_tools/case_creator.py
+++ b/client_tools/case_creator.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Simple Selenium automation to create a case via the web UI."""
+import time
+import json
+from selenium import webdriver
+from selenium.webdriver.edge.service import Service
+from selenium.webdriver.common.by import By
+from selenium.webdriver.edge.options import Options
+
+SERVER_URL = "http://localhost:5151"  # Update if needed
+ADMIN_USER = "admin"
+ADMIN_PASS = "secret"
+TEMPLATE_NAME = "Default"  # name of template to use
+
+
+def load_template_fields():
+    """Fetch template definition via HTTP."""
+    import requests
+    resp = requests.get(f"{SERVER_URL}/api/case-templates")
+    resp.raise_for_status()
+    data = resp.json()
+    for tpl in data.get("templates", []):
+        if tpl["name"] == TEMPLATE_NAME:
+            return tpl
+    raise RuntimeError("Template not found")
+
+
+def main():
+    tpl = load_template_fields()
+    fields = json.loads(tpl["fields_json"])
+
+    service = Service("client_tools/msedgedriver.exe")
+    opts = Options()
+    driver = webdriver.Edge(service=service, options=opts)
+
+    try:
+        driver.get(f"{SERVER_URL}/login")
+        driver.find_element(By.NAME, "username").send_keys(ADMIN_USER)
+        driver.find_element(By.NAME, "password").send_keys(ADMIN_PASS)
+        driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+        time.sleep(1)
+        driver.get(f"{SERVER_URL}/cases/new?template={tpl['id']}")
+        for f in fields:
+            elem = driver.find_element(By.NAME, f['id'])
+            if f['type'] == 'select':
+                from selenium.webdriver.support.ui import Select
+                Select(elem).select_by_index(0)
+            else:
+                elem.send_keys('test')
+        driver.find_element(By.CSS_SELECTOR, "button[type='submit']").click()
+        time.sleep(2)
+    finally:
+        driver.quit()
+
+
+if __name__ == '__main__':
+    main()

--- a/database_init.py
+++ b/database_init.py
@@ -73,6 +73,31 @@ def init_database():
                 UNIQUE(username, tool_id)
             )
         ''')
+
+        # Create case templates table
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS case_templates (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL,
+                fields_json TEXT NOT NULL,
+                created_at TEXT,
+                updated_at TEXT,
+                created_by TEXT
+            )
+        ''')
+
+        # Create cases table
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS cases (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                template_id INTEGER NOT NULL,
+                data_json TEXT NOT NULL,
+                created_at TEXT,
+                updated_at TEXT,
+                created_by TEXT,
+                FOREIGN KEY (template_id) REFERENCES case_templates(id)
+            )
+        ''')
         
         conn.commit()
         conn.close()

--- a/db_utils.py
+++ b/db_utils.py
@@ -804,3 +804,196 @@ def toggle_user_external_tool(username, tool_id):
     except Exception as e:
         print(f"Error toggling user external tool: {e}")
         return False, f"Failed to toggle tool: {str(e)}"
+
+
+# ---------------------------------------------------------------------------
+# Case Template Management Functions
+# ---------------------------------------------------------------------------
+
+def create_case_template(name, fields_json, created_by="admin"):
+    """Create a new case template."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            current_time = datetime.now().isoformat()
+
+            cursor.execute(
+                """
+                INSERT INTO case_templates (name, fields_json, created_at, updated_at, created_by)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (name, fields_json, current_time, current_time, created_by),
+            )
+
+            conn.commit()
+            return True, cursor.lastrowid
+
+    except Exception as e:
+        print(f"Error creating case template: {e}")
+        return False, str(e)
+
+
+def get_case_template(template_id):
+    """Retrieve a case template by ID."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT * FROM case_templates WHERE id = ?", (template_id,)
+            )
+            row = cursor.fetchone()
+            return dict(row) if row else None
+    except Exception as e:
+        print(f"Error getting case template {template_id}: {e}")
+        return None
+
+
+def get_case_template_by_name(name):
+    """Retrieve a case template by name."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT * FROM case_templates WHERE name = ?", (name,)
+            )
+            row = cursor.fetchone()
+            return dict(row) if row else None
+    except Exception as e:
+        print(f"Error getting case template by name {name}: {e}")
+        return None
+
+
+def list_case_templates():
+    """List all case templates."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT * FROM case_templates ORDER BY name"
+            )
+            return [dict(row) for row in cursor.fetchall()]
+    except Exception as e:
+        print(f"Error listing case templates: {e}")
+        return []
+
+
+def update_case_template(template_id, fields_json):
+    """Update the fields of a case template."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                UPDATE case_templates
+                SET fields_json = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (fields_json, datetime.now().isoformat(), template_id),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+    except Exception as e:
+        print(f"Error updating case template {template_id}: {e}")
+        return False
+
+
+def delete_case_template(template_id):
+    """Delete a case template."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "DELETE FROM case_templates WHERE id = ?",
+                (template_id,),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+    except Exception as e:
+        print(f"Error deleting case template {template_id}: {e}")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Case CRUD Functions
+# ---------------------------------------------------------------------------
+
+def create_case(template_id, data_json, created_by="admin"):
+    """Create a new case using a template."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            current_time = datetime.now().isoformat()
+            cursor.execute(
+                """
+                INSERT INTO cases (template_id, data_json, created_at, updated_at, created_by)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (template_id, data_json, current_time, current_time, created_by),
+            )
+            conn.commit()
+            return True, cursor.lastrowid
+    except Exception as e:
+        print(f"Error creating case: {e}")
+        return False, str(e)
+
+
+def get_case(case_id):
+    """Get case by ID."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT * FROM cases WHERE id = ?", (case_id,)
+            )
+            row = cursor.fetchone()
+            return dict(row) if row else None
+    except Exception as e:
+        print(f"Error getting case {case_id}: {e}")
+        return None
+
+
+def list_cases(limit=100):
+    """List cases, newest first."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT * FROM cases ORDER BY created_at DESC LIMIT ?", (limit,)
+            )
+            return [dict(row) for row in cursor.fetchall()]
+    except Exception as e:
+        print(f"Error listing cases: {e}")
+        return []
+
+
+def update_case(case_id, data_json):
+    """Update case data."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                UPDATE cases
+                SET data_json = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (data_json, datetime.now().isoformat(), case_id),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+    except Exception as e:
+        print(f"Error updating case {case_id}: {e}")
+        return False
+
+
+def delete_case(case_id):
+    """Delete a case."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("DELETE FROM cases WHERE id = ?", (case_id,))
+            conn.commit()
+            return cursor.rowcount > 0
+    except Exception as e:
+        print(f"Error deleting case {case_id}: {e}")
+        return False

--- a/external_tools_config.json
+++ b/external_tools_config.json
@@ -1,5 +1,14 @@
 {
-  "server_tools": [],
+  "server_tools": [
+    {
+      "id": "case_creator",
+      "name": "Case Creator",
+      "type": "client_service",
+      "executable_path": "case_creator.py",
+      "is_enabled": true,
+      "visible": true
+    }
+  ],
   "settings": {
     "allow_custom_tools": true,
     "allow_user_tools": true,

--- a/templates/admin_case_templates.html
+++ b/templates/admin_case_templates.html
@@ -1,0 +1,30 @@
+{% extends 'layout.html' %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h2><i class="bi bi-card-list"></i> Case Templates</h2>
+  <a href="{{ url_for('new_case_template') }}" class="btn btn-primary">New Template</a>
+</div>
+{% if templates %}
+<table class="table table-striped">
+  <thead>
+    <tr><th>ID</th><th>Name</th><th>Actions</th></tr>
+  </thead>
+  <tbody>
+  {% for tpl in templates %}
+    <tr>
+      <td>{{ tpl.id }}</td>
+      <td>{{ tpl.name }}</td>
+      <td>
+        <a href="{{ url_for('edit_case_template', template_id=tpl.id) }}" class="btn btn-sm btn-secondary">Edit</a>
+        <form method="post" action="{{ url_for('delete_case_template', template_id=tpl.id) }}" style="display:inline" onsubmit="return confirm('Delete template {{ tpl.name }}?');">
+          <button class="btn btn-sm btn-danger">Delete</button>
+        </form>
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>No templates found.</p>
+{% endif %}
+{% endblock %}

--- a/templates/case_form.html
+++ b/templates/case_form.html
@@ -1,0 +1,26 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>{{ 'Edit' if case else 'New' }} Case - {{ template.name }}</h2>
+{% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+<form method="post">
+  <input type="hidden" name="template_id" value="{{ template.id }}">
+  {% for field in fields %}
+  <div class="mb-3">
+    <label class="form-label">{{ field.name }}</label>
+    {% if field.type == 'textarea' %}
+      <textarea name="{{ field.id }}" class="form-control">{{ data.get(field.id, '') }}</textarea>
+    {% elif field.type == 'select' %}
+      <select name="{{ field.id }}" class="form-select">
+        {% for opt in field.options %}
+          <option value="{{ opt.value }}" {% if data.get(field.id) == opt.value %}selected{% endif %}>{{ opt.label }}</option>
+        {% endfor %}
+      </select>
+    {% else %}
+      <input type="text" name="{{ field.id }}" class="form-control" value="{{ data.get(field.id,'') }}">
+    {% endif %}
+  </div>
+  {% endfor %}
+  <button type="submit" class="btn btn-primary">Save</button>
+  <a href="{{ url_for('case_list') }}" class="btn btn-secondary">Cancel</a>
+</form>
+{% endblock %}

--- a/templates/case_template_form.html
+++ b/templates/case_template_form.html
@@ -1,0 +1,18 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>{{ 'Edit' if template else 'New' }} Case Template</h2>
+{% if error %}<div class="alert alert-danger">{{ error }}</div>{% endif %}
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Template Name</label>
+    <input type="text" class="form-control" name="name" value="{{ template.name if template else '' }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Fields JSON</label>
+    <textarea name="fields_json" class="form-control" rows="10" required>{{ template.fields_json if template else example_json }}</textarea>
+    <small class="form-text text-muted">Edit the JSON describing fields and dependencies.</small>
+  </div>
+  <button type="submit" class="btn btn-primary">Save</button>
+  <a href="{{ url_for('manage_case_templates') }}" class="btn btn-secondary">Cancel</a>
+</form>
+{% endblock %}

--- a/templates/cases.html
+++ b/templates/cases.html
@@ -1,0 +1,38 @@
+{% extends 'layout.html' %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <h2><i class="bi bi-clipboard-check"></i> Cases</h2>
+  <a href="{{ url_for('new_case') }}" class="btn btn-primary">New Case</a>
+</div>
+{% if cases %}
+<div class="table-responsive">
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Template</th>
+        <th>Created</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for case in cases %}
+      <tr>
+        <td>{{ case.id }}</td>
+        <td>{{ templates[case.template_id] }}</td>
+        <td>{{ case.created_at[:19] if case.created_at else '' }}</td>
+        <td>
+          <a href="{{ url_for('edit_case', case_id=case.id) }}" class="btn btn-sm btn-secondary">Edit</a>
+          <form method="post" action="{{ url_for('delete_case', case_id=case.id) }}" style="display:inline" onsubmit="return confirm('Delete case {{ case.id }}?');">
+            <button class="btn btn-sm btn-danger" type="submit">Delete</button>
+          </form>
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% else %}
+<p>No cases found.</p>
+{% endif %}
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -32,6 +32,9 @@
             <li class="nav-item">
               <a class="nav-link" href="/resources-admin">Resource CFG</a>
             </li>
+            <li class="nav-item">
+              <a class="nav-link" href="/cases">Cases</a>
+            </li>
             {% if session.get('secret_admin') %}
             <li class="nav-item">
               <a class="nav-link" href="/admin/external-tools">External Tools CFG</a>

--- a/tests/test_db_cases.py
+++ b/tests/test_db_cases.py
@@ -1,0 +1,48 @@
+import json
+import os
+import sqlite3
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import db_utils
+
+
+def setup_module(module):
+    # ensure tables exist
+    from database_init import init_database
+    init_database()
+
+
+def teardown_function(function):
+    # cleanup created rows
+    with db_utils.get_db_connection() as conn:
+        conn.execute('DELETE FROM cases')
+        conn.execute('DELETE FROM case_templates')
+        conn.commit()
+
+
+def test_case_template_crud():
+    ok, tid = db_utils.create_case_template('temp1', json.dumps([{"id":"f","name":"F","type":"text"}]))
+    assert ok
+    tpl = db_utils.get_case_template(tid)
+    assert tpl['name'] == 'temp1'
+    assert db_utils.update_case_template(tid, json.dumps([{"id":"x","name":"X","type":"text"}]))
+    tpl2 = db_utils.get_case_template(tid)
+    assert 'x' in tpl2['fields_json']
+    assert db_utils.delete_case_template(tid)
+    assert db_utils.get_case_template(tid) is None
+
+
+def test_case_crud():
+    ok, tid = db_utils.create_case_template('temp2', json.dumps([{"id":"f","name":"F","type":"text"}]))
+    assert ok
+    ok, cid = db_utils.create_case(tid, json.dumps({'f':'v'}), 'tester')
+    assert ok
+    case = db_utils.get_case(cid)
+    assert json.loads(case['data_json'])['f'] == 'v'
+    assert db_utils.update_case(cid, json.dumps({'f':'z'}))
+    case2 = db_utils.get_case(cid)
+    assert json.loads(case2['data_json'])['f'] == 'z'
+    assert db_utils.delete_case(cid)
+    db_utils.delete_case_template(tid)


### PR DESCRIPTION
## Summary
- add case tables in database initialization
- implement case and case template helpers in `db_utils`
- create routes and templates for managing cases
- integrate simple Selenium automation script
- document case management usage in README
- expose `case_creator` tool in external tools config
- add tests for new DB helpers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b0fbffb08321a9f137a0d2d9907f