### PR TITLE
Reintroduce case management

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Create a Python virtual environment and install dependencies:
 ```bash
 python3 -m venv venv
 source venv/bin/activate
-pip install Flask
+pip install -r requirements.txt
 ```
 
 ## Running the site
@@ -27,4 +27,23 @@ Open `http://localhost:5000` in your browser (or the host/port you configure).
 Use the **Login** link to enter the admin password and create new posts. The
 default password can be set with the `TRUCKSOFT_ADMIN_PASSWORD` environment
 variable. The host and port may be customized with `TRUCKSOFT_HOST` and
+`TRUCKSOFT_PORT`.
+
+### Case Management
+
+Admins can create reusable case templates from **Case Templates** in the
+navigation bar. Templates define fields using JSON and optional dependency
+rules. Once a template exists, open the **Cases** page to file new cases or
+edit existing ones.
+
+### Selenium Automation
+
+The `client_tools/case_creator.py` script demonstrates automated case creation
+with Selenium. Download the Microsoft Edge WebDriver that matches your browser
+version and place `msedgedriver.exe` in the `client_tools` directory. Adjust the
+settings in `case_creator_config.json` then run:
+
+```bash
+python client_tools/case_creator.py
+```
 

--- a/app.py
+++ b/app.py
@@ -2043,6 +2043,144 @@ def manage_table_data(table_name):
                          success=success)
 
 
+# ---------------------------------------------------------------------------
+# Case Templates Management
+# ---------------------------------------------------------------------------
+
+@app.route('/admin/case-templates')
+def case_templates():
+    if not session.get('logged_in') or not session.get('secret_admin'):
+        return redirect(url_for('login'))
+    try:
+        from db_utils import get_case_templates
+        templates = get_case_templates()
+    except Exception as e:
+        print(f"Error loading case templates: {e}")
+        templates = []
+    return render_template('admin_case_templates.html', templates=templates)
+
+
+@app.route('/admin/case-templates/new', methods=['GET', 'POST'])
+def new_case_template():
+    if not session.get('logged_in') or not session.get('secret_admin'):
+        return redirect(url_for('login'))
+    error = None
+    if request.method == 'POST':
+        name = request.form.get('name', '').strip()
+        description = request.form.get('description', '').strip()
+        fields_json = request.form.get('fields', '[]')
+        rules_json = request.form.get('rules', '[]')
+        try:
+            fields = json.loads(fields_json)
+            rules = json.loads(rules_json) if rules_json else []
+            from db_utils import create_case_template
+            create_case_template(name, description, fields, rules, session.get('username', 'admin'))
+            return redirect(url_for('case_templates'))
+        except Exception as e:
+            error = f"Error saving template: {e}"
+    return render_template('case_template_form.html', template=None, error=error)
+
+
+@app.route('/admin/case-templates/<int:template_id>/edit', methods=['GET', 'POST'])
+def edit_case_template(template_id):
+    if not session.get('logged_in') or not session.get('secret_admin'):
+        return redirect(url_for('login'))
+    error = None
+    from db_utils import get_case_template, update_case_template
+    template = get_case_template(template_id)
+    if not template:
+        return redirect(url_for('case_templates'))
+    if request.method == 'POST':
+        name = request.form.get('name', '').strip()
+        description = request.form.get('description', '').strip()
+        fields_json = request.form.get('fields', '[]')
+        rules_json = request.form.get('rules', '[]')
+        try:
+            fields = json.loads(fields_json)
+            rules = json.loads(rules_json) if rules_json else []
+            update_case_template(template_id, name, description, fields, rules)
+            return redirect(url_for('case_templates'))
+        except Exception as e:
+            error = f"Error updating template: {e}"
+    return render_template('case_template_form.html', template=template, error=error)
+
+
+@app.route('/admin/case-templates/<int:template_id>/delete', methods=['POST'])
+def delete_case_template(template_id):
+    if not session.get('logged_in') or not session.get('secret_admin'):
+        return redirect(url_for('login'))
+    from db_utils import delete_case_template
+    delete_case_template(template_id)
+    return redirect(url_for('case_templates'))
+
+
+# ---------------------------------------------------------------------------
+# Cases CRUD
+# ---------------------------------------------------------------------------
+
+@app.route('/cases')
+def cases():
+    if not session.get('logged_in'):
+        return redirect(url_for('login'))
+    search = request.args.get('search', '').lower()
+    template_filter = request.args.get('template', 'all')
+    from db_utils import get_all_cases, get_case_templates
+    cases = get_all_cases()
+    templates = get_case_templates()
+    filtered = []
+    for c in cases:
+        if template_filter != 'all' and str(c['template_id']) != template_filter:
+            continue
+        if search and search not in json.dumps(c['case_data']).lower():
+            continue
+        filtered.append(c)
+    return render_template('cases.html', cases=filtered, templates=templates, search=search, template_filter=template_filter)
+
+
+@app.route('/cases/new', methods=['GET', 'POST'])
+def new_case():
+    if not session.get('logged_in'):
+        return redirect(url_for('login'))
+    template_id = request.args.get('template_id') or request.form.get('template_id')
+    from db_utils import get_case_templates, get_case_template, create_case
+    if not template_id:
+        templates = get_case_templates()
+        if not templates:
+            return redirect(url_for('case_templates'))
+        template_id = templates[0]['id']
+    template = get_case_template(int(template_id))
+    if request.method == 'POST':
+        case_data = {f['id']: request.form.get(f['id'], '') for f in template['fields']}
+        create_case(template['id'], case_data, session.get('username', 'admin'))
+        return redirect(url_for('cases'))
+    return render_template('case_form.html', template=template, case=None)
+
+
+@app.route('/cases/edit/<int:case_id>', methods=['GET', 'POST'])
+def edit_case(case_id):
+    if not session.get('logged_in'):
+        return redirect(url_for('login'))
+    from db_utils import get_case, get_case_template, update_case
+    case = get_case(case_id)
+    if not case:
+        return redirect(url_for('cases'))
+    template = get_case_template(case['template_id'])
+    if request.method == 'POST':
+        case_data = {f['id']: request.form.get(f['id'], '') for f in template['fields']}
+        update_case(case_id, case_data)
+        return redirect(url_for('cases'))
+    return render_template('case_form.html', template=template, case=case)
+
+
+@app.route('/cases/delete/<int:case_id>', methods=['POST'])
+def delete_case(case_id):
+    if not session.get('logged_in'):
+        return redirect(url_for('login'))
+    from db_utils import delete_case
+    delete_case(case_id)
+    return redirect(url_for('cases'))
+
+
 @app.route('/api/data-tables')
 def api_get_data_tables():
     """API endpoint to get list of custom data tables for other integrations."""
@@ -2096,6 +2234,27 @@ def api_get_table_data(table_name):
     except Exception as e:
         print(f"Error in API get table data for {table_name}: {e}")
         return jsonify({'error': 'Failed to load table data'}), 500
+
+
+@app.route('/api/data-tables/<table_name>/related')
+def api_get_related_data(table_name):
+    """Return a single row from a table matching a column value."""
+    if not session.get('logged_in'):
+        return jsonify({'error': 'Not authenticated'}), 401
+
+    column = request.args.get('column', '')
+    value = request.args.get('value', '')
+    return_cols = request.args.getlist('return')
+
+    try:
+        from db_utils import get_custom_table_related_data
+        row = get_custom_table_related_data(f"custom_{table_name}", column, value, return_cols)
+        if row is None:
+            return jsonify({'success': True, 'row': None})
+        return jsonify({'success': True, 'row': row})
+    except Exception as e:
+        print(f"Error getting related data for {table_name}: {e}")
+        return jsonify({'error': 'Failed to get related data'}), 500
 
 
 if __name__ == '__main__':

--- a/client_tools/case_creator.py
+++ b/client_tools/case_creator.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Simple Selenium automation script to create a case."""
+
+import json
+import time
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.edge.service import Service
+from selenium.webdriver.edge.options import Options
+import os
+
+CONFIG_FILE = os.path.join(os.path.dirname(__file__), 'case_creator_config.json')
+
+
+def load_config():
+    if os.path.exists(CONFIG_FILE):
+        with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return {
+        "url": "http://localhost:5151",
+        "username": "admin",
+        "password": "secret",
+        "template_id": 1,
+        "fields": {}
+    }
+
+
+def main():
+    config = load_config()
+    driver_path = os.path.join(os.path.dirname(__file__), 'msedgedriver.exe')
+    options = Options()
+    options.add_argument('--headless')
+    service = Service(driver_path)
+    driver = webdriver.Edge(service=service, options=options)
+
+    try:
+        driver.get(f"{config['url']}/login")
+        driver.find_element(By.NAME, 'username').send_keys(config['username'])
+        driver.find_element(By.NAME, 'password').send_keys(config['password'])
+        driver.find_element(By.CSS_SELECTOR, 'button[type=submit]').click()
+        time.sleep(1)
+
+        driver.get(f"{config['url']}/cases/new?template_id={config['template_id']}")
+        for field_id, value in config.get('fields', {}).items():
+            elem = driver.find_element(By.NAME, field_id)
+            elem.clear()
+            elem.send_keys(value)
+        driver.find_element(By.CSS_SELECTOR, 'button[type=submit]').click()
+        time.sleep(1)
+    finally:
+        driver.quit()
+
+
+if __name__ == '__main__':
+    main()

--- a/client_tools/case_creator_config.json
+++ b/client_tools/case_creator_config.json
@@ -1,0 +1,10 @@
+{
+  "url": "http://localhost:5151",
+  "username": "admin",
+  "password": "secret",
+  "template_id": 1,
+  "fields": {
+    "subject": "Automated case",
+    "description": "Created by Selenium"
+  }
+}

--- a/database_init.py
+++ b/database_init.py
@@ -73,6 +73,34 @@ def init_database():
                 UNIQUE(username, tool_id)
             )
         ''')
+
+        # Create case templates table
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS case_templates (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT UNIQUE NOT NULL,
+                description TEXT,
+                fields_json TEXT NOT NULL,
+                rules_json TEXT,
+                created_at TEXT,
+                updated_at TEXT,
+                created_by TEXT
+            )
+        ''')
+
+        # Create cases table
+        cursor.execute('''
+            CREATE TABLE IF NOT EXISTS cases (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                template_id INTEGER NOT NULL,
+                case_data TEXT NOT NULL,
+                status TEXT DEFAULT 'open',
+                created_at TEXT,
+                updated_at TEXT,
+                created_by TEXT,
+                FOREIGN KEY (template_id) REFERENCES case_templates(id)
+            )
+        ''')
         
         conn.commit()
         conn.close()

--- a/db_utils.py
+++ b/db_utils.py
@@ -4,6 +4,7 @@ This module provides safe database operations with proper error handling.
 """
 
 import sqlite3
+import json
 from datetime import datetime
 from werkzeug.security import generate_password_hash, check_password_hash
 from contextlib import contextmanager
@@ -804,3 +805,284 @@ def toggle_user_external_tool(username, tool_id):
     except Exception as e:
         print(f"Error toggling user external tool: {e}")
         return False, f"Failed to toggle tool: {str(e)}"
+
+
+# ---------------------------------------------------------------------------
+# Case Management Functions
+# ---------------------------------------------------------------------------
+
+def create_case_template(name, description, fields, rules=None, created_by="admin"):
+    """Create a case template."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+
+            current_time = datetime.now().isoformat()
+            cursor.execute(
+                """
+                INSERT INTO case_templates
+                (name, description, fields_json, rules_json, created_at, updated_at, created_by)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    name,
+                    description,
+                    json.dumps(fields),
+                    json.dumps(rules or []),
+                    current_time,
+                    current_time,
+                    created_by,
+                ),
+            )
+
+            conn.commit()
+            return cursor.lastrowid, "Template created"
+
+    except Exception as e:
+        print(f"Error creating case template: {e}")
+        return None, str(e)
+
+
+def get_case_templates():
+    """Return all case templates."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT * FROM case_templates ORDER BY created_at DESC"
+            )
+            templates = []
+            for row in cursor.fetchall():
+                templates.append(
+                    {
+                        "id": row["id"],
+                        "name": row["name"],
+                        "description": row["description"],
+                        "fields": json.loads(row["fields_json"]),
+                        "rules": json.loads(row["rules_json"] or "[]"),
+                        "created_at": row["created_at"],
+                        "updated_at": row["updated_at"],
+                        "created_by": row["created_by"],
+                    }
+                )
+            return templates
+
+    except Exception as e:
+        print(f"Error getting case templates: {e}")
+        return []
+
+
+def get_case_template(template_id):
+    """Get a single case template by ID."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT * FROM case_templates WHERE id = ?",
+                (template_id,),
+            )
+            row = cursor.fetchone()
+            if not row:
+                return None
+
+            return {
+                "id": row["id"],
+                "name": row["name"],
+                "description": row["description"],
+                "fields": json.loads(row["fields_json"]),
+                "rules": json.loads(row["rules_json"] or "[]"),
+                "created_at": row["created_at"],
+                "updated_at": row["updated_at"],
+                "created_by": row["created_by"],
+            }
+
+    except Exception as e:
+        print(f"Error getting case template {template_id}: {e}")
+        return None
+
+
+def update_case_template(template_id, name, description, fields, rules=None):
+    """Update an existing case template."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                UPDATE case_templates
+                SET name = ?, description = ?, fields_json = ?, rules_json = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    name,
+                    description,
+                    json.dumps(fields),
+                    json.dumps(rules or []),
+                    datetime.now().isoformat(),
+                    template_id,
+                ),
+            )
+
+            conn.commit()
+            return cursor.rowcount > 0
+
+    except Exception as e:
+        print(f"Error updating case template {template_id}: {e}")
+        return False
+
+
+def delete_case_template(template_id):
+    """Delete a case template."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "DELETE FROM case_templates WHERE id = ?",
+                (template_id,),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+
+    except Exception as e:
+        print(f"Error deleting case template {template_id}: {e}")
+        return False
+
+
+def create_case(template_id, case_data, created_by="admin", status="open"):
+    """Create a new case."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+
+            current_time = datetime.now().isoformat()
+            cursor.execute(
+                """
+                INSERT INTO cases (template_id, case_data, status, created_at, updated_at, created_by)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    template_id,
+                    json.dumps(case_data),
+                    status,
+                    current_time,
+                    current_time,
+                    created_by,
+                ),
+            )
+
+            conn.commit()
+            return cursor.lastrowid, "Case created"
+
+    except Exception as e:
+        print(f"Error creating case: {e}")
+        return None, str(e)
+
+
+def get_all_cases():
+    """Retrieve all cases with template names."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT c.id, c.template_id, c.case_data, c.status, c.created_at, c.updated_at, c.created_by,
+                       t.name as template_name
+                FROM cases c
+                JOIN case_templates t ON c.template_id = t.id
+                ORDER BY c.created_at DESC
+                """
+            )
+            cases = []
+            for row in cursor.fetchall():
+                cases.append(
+                    {
+                        "id": row["id"],
+                        "template_id": row["template_id"],
+                        "template_name": row["template_name"],
+                        "case_data": json.loads(row["case_data"]),
+                        "status": row["status"],
+                        "created_at": row["created_at"],
+                        "updated_at": row["updated_at"],
+                        "created_by": row["created_by"],
+                    }
+                )
+            return cases
+
+    except Exception as e:
+        print(f"Error getting cases: {e}")
+        return []
+
+
+def get_case(case_id):
+    """Retrieve a single case by ID."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT c.id, c.template_id, c.case_data, c.status, c.created_at, c.updated_at, c.created_by,
+                       t.name as template_name
+                FROM cases c
+                JOIN case_templates t ON c.template_id = t.id
+                WHERE c.id = ?
+                """,
+                (case_id,),
+            )
+            row = cursor.fetchone()
+            if not row:
+                return None
+
+            return {
+                "id": row["id"],
+                "template_id": row["template_id"],
+                "template_name": row["template_name"],
+                "case_data": json.loads(row["case_data"]),
+                "status": row["status"],
+                "created_at": row["created_at"],
+                "updated_at": row["updated_at"],
+                "created_by": row["created_by"],
+            }
+
+    except Exception as e:
+        print(f"Error getting case {case_id}: {e}")
+        return None
+
+
+def update_case(case_id, case_data, status=None):
+    """Update case details."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+
+            fields = ["case_data = ?", "updated_at = ?"]
+            values = [json.dumps(case_data), datetime.now().isoformat()]
+            if status is not None:
+                fields.append("status = ?")
+                values.append(status)
+            values.append(case_id)
+
+            cursor.execute(
+                f"UPDATE cases SET {', '.join(fields)} WHERE id = ?",
+                values,
+            )
+
+            conn.commit()
+            return cursor.rowcount > 0
+
+    except Exception as e:
+        print(f"Error updating case {case_id}: {e}")
+        return False
+
+
+def delete_case(case_id):
+    """Delete a case."""
+    try:
+        with get_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("DELETE FROM cases WHERE id = ?", (case_id,))
+            conn.commit()
+            return cursor.rowcount > 0
+
+    except Exception as e:
+        print(f"Error deleting case {case_id}: {e}")
+        return False
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 Flask
+selenium
+pytest

--- a/static/js/case-form.js
+++ b/static/js/case-form.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const rulesEl = document.getElementById('case-rules');
+  if (!rulesEl) return;
+  let rules = [];
+  try { rules = JSON.parse(rulesEl.dataset.rules || '[]'); } catch(e) { console.error(e); }
+
+  rules.forEach(rule => {
+    const src = document.querySelector(`[name="${rule.source}"]`);
+    if (src) {
+      src.addEventListener('change', () => applyRule(rule, src.value));
+    }
+  });
+
+  function applyRule(rule, value) {
+    if (!rule.table || !rule.match_column) return;
+    const params = new URLSearchParams();
+    params.append('column', rule.match_column);
+    params.append('value', value);
+    if (rule.map) {
+      Object.values(rule.map).forEach(c => params.append('return', c));
+    }
+    fetch(`/api/data-tables/${rule.table}/related?` + params.toString())
+      .then(r => r.json())
+      .then(data => {
+        if (data.success && data.row) {
+          Object.entries(rule.map || {}).forEach(([fieldId, col]) => {
+            if (data.row[col] !== undefined) {
+              const tgt = document.querySelector(`[name="${fieldId}"]`);
+              if (tgt) tgt.value = data.row[col];
+            }
+          });
+        }
+      })
+      .catch(err => console.error('Case rule error', err));
+  }
+});

--- a/templates/admin_case_templates.html
+++ b/templates/admin_case_templates.html
@@ -1,0 +1,25 @@
+{% extends 'layout.html' %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h2 class="mb-0">Case Templates</h2>
+  <a href="{{ url_for('new_case_template') }}" class="btn btn-primary">New Template</a>
+</div>
+<table class="table table-striped">
+  <thead><tr><th>ID</th><th>Name</th><th>Created</th><th></th></tr></thead>
+  <tbody>
+    {% for t in templates %}
+    <tr>
+      <td>{{ t.id }}</td>
+      <td>{{ t.name }}</td>
+      <td>{{ t.created_at }}</td>
+      <td>
+        <a href="{{ url_for('edit_case_template', template_id=t.id) }}" class="btn btn-sm btn-primary">Edit</a>
+        <form method="post" action="{{ url_for('delete_case_template', template_id=t.id) }}" style="display:inline-block" onsubmit="return confirm('Delete template?');">
+          <button class="btn btn-sm btn-danger">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/case_form.html
+++ b/templates/case_form.html
@@ -1,0 +1,26 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>{{ 'Edit Case' if case else 'New Case' }}</h2>
+<form method="post">
+  {% for field in template.fields %}
+  <div class="mb-3">
+    <label class="form-label">{{ field.name }}</label>
+    {% if field.type == 'textarea' %}
+      <textarea name="{{ field.id }}" class="form-control case-field" rows="{{ field.rows or 3 }}" {% if field.required %}required{% endif %}>{{ case.case_data[field.id] if case else '' }}</textarea>
+    {% elif field.type == 'select' %}
+      <select name="{{ field.id }}" class="form-select case-field" {% if field.required %}required{% endif %}>
+        {% for opt in field.options %}
+        <option value="{{ opt.value }}" {% if case and case.case_data[field.id]==opt.value %}selected{% endif %}>{{ opt.label }}</option>
+        {% endfor %}
+      </select>
+    {% else %}
+      <input type="text" name="{{ field.id }}" class="form-control case-field" value="{{ case.case_data[field.id] if case else '' }}" {% if field.required %}required{% endif %}
+             data-field-id="{{ field.id }}">
+    {% endif %}
+  </div>
+  {% endfor %}
+  <button class="btn btn-primary" type="submit">Save</button>
+</form>
+<div id="case-rules" data-rules='{{ template.rules|tojson|safe }}'></div>
+<script src="{{ url_for('static', filename='js/case-form.js') }}"></script>
+{% endblock %}

--- a/templates/case_template_form.html
+++ b/templates/case_template_form.html
@@ -1,0 +1,25 @@
+{% extends 'layout.html' %}
+{% block content %}
+<h2>{{ 'Edit Case Template' if template else 'New Case Template' }}</h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Template Name</label>
+    <input type="text" class="form-control" name="name" value="{{ template.name if template }}" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Description</label>
+    <textarea class="form-control" name="description">{{ template.description if template }}</textarea>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Fields JSON</label>
+    <textarea class="form-control" name="fields" rows="6" required>{{ template.fields|tojson if template }}</textarea>
+    <small class="form-text text-muted">Provide an array of field objects.</small>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Rules JSON</label>
+    <textarea class="form-control" name="rules" rows="4">{{ template.rules|tojson if template }}</textarea>
+    <small class="form-text text-muted">Optional dependent field rules.</small>
+  </div>
+  <button class="btn btn-primary" type="submit">Save Template</button>
+</form>
+{% endblock %}

--- a/templates/cases.html
+++ b/templates/cases.html
@@ -1,0 +1,44 @@
+{% extends 'layout.html' %}
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h2 class="mb-0">Cases</h2>
+  <a href="{{ url_for('new_case') }}" class="btn btn-primary">New Case</a>
+</div>
+<form method="get" class="row g-2 mb-3">
+  <div class="col-md-4">
+    <input type="text" class="form-control" name="search" placeholder="Search" value="{{ search or '' }}">
+  </div>
+  <div class="col-md-4">
+    <select class="form-select" name="template">
+      <option value="all">All Templates</option>
+      {% for t in templates %}
+      <option value="{{ t.id }}" {% if template_filter==t.id|string %}selected{% endif %}>{{ t.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-md-4">
+    <button class="btn btn-secondary" type="submit">Filter</button>
+  </div>
+</form>
+<table class="table table-striped">
+  <thead>
+    <tr><th>ID</th><th>Template</th><th>Created</th><th>Status</th><th>Actions</th></tr>
+  </thead>
+  <tbody>
+    {% for c in cases %}
+    <tr>
+      <td>{{ c.id }}</td>
+      <td>{{ c.template_name }}</td>
+      <td>{{ c.created_at }}</td>
+      <td>{{ c.status }}</td>
+      <td>
+        <a href="{{ url_for('edit_case', case_id=c.id) }}" class="btn btn-sm btn-primary">Edit</a>
+        <form method="post" action="{{ url_for('delete_case', case_id=c.id) }}" style="display:inline-block" onsubmit="return confirm('Delete case?');">
+          <button class="btn btn-sm btn-danger">Delete</button>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -26,22 +26,28 @@
             <li class="nav-item">
               <a class="nav-link" href="/new">New Post</a>
             </li>
-            <li class="nav-item">
-              <a class="nav-link" href="/categories">Categories</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="/resources-admin">Resource CFG</a>
-            </li>
+              <li class="nav-item">
+                <a class="nav-link" href="/categories">Categories</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="/cases">Cases</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="/resources-admin">Resource CFG</a>
+              </li>
             {% if session.get('secret_admin') %}
             <li class="nav-item">
               <a class="nav-link" href="/admin/external-tools">External Tools CFG</a>
             </li>
-            <li class="nav-item">
-              <a class="nav-link" href="/admin/data-tables">Data Tables</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="/manage-admins">Admin CFG</a>
-            </li>
+              <li class="nav-item">
+                <a class="nav-link" href="/admin/data-tables">Data Tables</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="/admin/case-templates">Case Templates</a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link" href="/manage-admins">Admin CFG</a>
+              </li>
             {% endif %}
             <li class="nav-item">
               <a class="nav-link" href="/account"><i class="bi bi-person-circle"></i> My Account</a>

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -1,0 +1,85 @@
+import sqlite3
+import json
+import types
+import os
+import sys
+from contextlib import contextmanager
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import db_utils
+
+
+def setup_memory_db():
+    conn = sqlite3.connect(':memory:')
+    conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+    cursor.executescript('''
+        CREATE TABLE case_templates (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT UNIQUE NOT NULL,
+            description TEXT,
+            fields_json TEXT NOT NULL,
+            rules_json TEXT,
+            created_at TEXT,
+            updated_at TEXT,
+            created_by TEXT
+        );
+        CREATE TABLE cases (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            template_id INTEGER NOT NULL,
+            case_data TEXT NOT NULL,
+            status TEXT DEFAULT 'open',
+            created_at TEXT,
+            updated_at TEXT,
+            created_by TEXT
+        );
+    ''')
+    return conn
+
+
+@contextmanager
+def memory_connection(conn):
+    try:
+        yield conn
+    finally:
+        pass
+
+
+def patch_db(monkeypatch, conn):
+    monkeypatch.setattr(db_utils, 'get_db_connection', lambda: memory_connection(conn))
+
+
+def test_case_template_crud(monkeypatch):
+    conn = setup_memory_db()
+    patch_db(monkeypatch, conn)
+
+    tid, msg = db_utils.create_case_template('T1', 'desc', [{'id': 'f', 'name': 'F', 'type': 'text'}])
+    assert tid is not None
+
+    templates = db_utils.get_case_templates()
+    assert len(templates) == 1
+    assert templates[0]['name'] == 'T1'
+
+    db_utils.update_case_template(tid, 'T1b', 'd', [{'id': 'f', 'name': 'F', 'type': 'text'}])
+    t = db_utils.get_case_template(tid)
+    assert t['name'] == 'T1b'
+
+    db_utils.delete_case_template(tid)
+    assert db_utils.get_case_template(tid) is None
+
+
+def test_case_crud(monkeypatch):
+    conn = setup_memory_db()
+    patch_db(monkeypatch, conn)
+
+    tid, _ = db_utils.create_case_template('T2', '', [{'id': 'a', 'name': 'A', 'type': 'text'}])
+    cid, _ = db_utils.create_case(tid, {'a': '1'})
+    case = db_utils.get_case(cid)
+    assert case['case_data']['a'] == '1'
+
+    db_utils.update_case(cid, {'a': '2'}, status='closed')
+    case = db_utils.get_case(cid)
+    assert case['status'] == 'closed'
+
+    db_utils.delete_case(cid)
+    assert db_utils.get_case(cid) is None


### PR DESCRIPTION
## Summary
- add case tables to the DB and case utilities
- implement admin CRUD routes and UI templates for cases
- support dependent field lookup with new API and JS
- provide Selenium automation script and config
- document case workflow and automation in README
- include unit tests for the new db utilities

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b0fbffb08321a9f137a0d2d9907f