### PR TITLE
Fix template management routes and editor

### DIFF
--- a/enhanced_db_utils.py
+++ b/enhanced_db_utils.py
@@ -8,12 +8,13 @@ import json
 from datetime import datetime
 from contextlib import contextmanager
 
+
 @contextmanager
 def get_enhanced_db_connection():
     """Context manager for enhanced database connections."""
     conn = None
     try:
-        conn = sqlite3.connect('enhanced_database.db')
+        conn = sqlite3.connect("enhanced_database.db")
         conn.row_factory = sqlite3.Row
         yield conn
     except Exception as e:
@@ -24,46 +25,57 @@ def get_enhanced_db_connection():
         if conn:
             conn.close()
 
+
 # Data Table Management Functions
 
-def create_data_table(table_name, display_name, description, columns, created_by="admin"):
+
+def create_data_table(
+    table_name, display_name, description, columns, created_by="admin"
+):
     """Create a new data table with specified columns."""
     try:
         with get_enhanced_db_connection() as conn:
             cursor = conn.cursor()
             current_time = datetime.now().isoformat()
-            
+
             # Create the data table record
-            cursor.execute('''
+            cursor.execute(
+                """
                 INSERT INTO data_tables (table_name, display_name, description, created_at, created_by)
                 VALUES (?, ?, ?, ?, ?)
-            ''', (table_name, display_name, description, current_time, created_by))
-            
+            """,
+                (table_name, display_name, description, current_time, created_by),
+            )
+
             table_id = cursor.lastrowid
-            
+
             # Create columns
             for column in columns:
-                cursor.execute('''
+                cursor.execute(
+                    """
                     INSERT INTO data_table_columns 
                     (table_id, column_name, display_name, data_type, is_key_field, is_display_field, is_searchable, validation_rules, created_at)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ''', (
-                    table_id,
-                    column['column_name'],
-                    column['display_name'],
-                    column['data_type'],
-                    column.get('is_key_field', 0),
-                    column.get('is_display_field', 0),
-                    column.get('is_searchable', 1),
-                    json.dumps(column.get('validation_rules', {})),
-                    current_time
-                ))
-            
+                """,
+                    (
+                        table_id,
+                        column["column_name"],
+                        column["display_name"],
+                        column["data_type"],
+                        column.get("is_key_field", 0),
+                        column.get("is_display_field", 0),
+                        column.get("is_searchable", 1),
+                        json.dumps(column.get("validation_rules", {})),
+                        current_time,
+                    ),
+                )
+
             conn.commit()
             return table_id, "Data table created successfully"
-            
+
     except Exception as e:
         return None, f"Error creating data table: {str(e)}"
+
 
 def add_data_table_record(table_id, record_data, created_by="admin"):
     """Add a record to a data table."""
@@ -71,70 +83,106 @@ def add_data_table_record(table_id, record_data, created_by="admin"):
         with get_enhanced_db_connection() as conn:
             cursor = conn.cursor()
             current_time = datetime.now().isoformat()
-            
-            cursor.execute('''
+
+            cursor.execute(
+                """
                 INSERT INTO data_table_records (table_id, record_data, created_at, created_by)
                 VALUES (?, ?, ?, ?)
-            ''', (table_id, json.dumps(record_data), current_time, created_by))
-            
+            """,
+                (table_id, json.dumps(record_data), current_time, created_by),
+            )
+
             conn.commit()
             return cursor.lastrowid, "Record added successfully"
-            
+
     except Exception as e:
         return None, f"Error adding record: {str(e)}"
 
-def search_data_table(table_id, search_term="", limit=10):
+
+def search_data_table(table_id, search_term="", limit=10, display_column=None):
     """Search records in a data table."""
     try:
         with get_enhanced_db_connection() as conn:
             cursor = conn.cursor()
-            
+
             # Get table columns
-            cursor.execute('''
+            cursor.execute(
+                """
                 SELECT column_name, display_name, is_display_field, is_searchable
                 FROM data_table_columns 
                 WHERE table_id = ? 
                 ORDER BY is_key_field DESC, is_display_field DESC
-            ''', (table_id,))
+            """,
+                (table_id,),
+            )
             columns = cursor.fetchall()
-            
+
             # Get records
-            query = '''
+            query = """
                 SELECT id, record_data 
                 FROM data_table_records 
                 WHERE table_id = ? AND is_active = 1
-            '''
+            """
             params = [table_id]
-            
+
             if search_term:
-                query += ' AND record_data LIKE ?'
-                params.append(f'%{search_term}%')
-            
-            query += ' LIMIT ?'
+                query += " AND record_data LIKE ?"
+                params.append(f"%{search_term}%")
+
+            query += " LIMIT ?"
             params.append(limit)
-            
+
             cursor.execute(query, params)
             records = cursor.fetchall()
-            
+
             # Format results
             results = []
             for record in records:
-                data = json.loads(record['record_data'])
-                display_field = next((col['column_name'] for col in columns if col['is_display_field']), 
-                                   columns[0]['column_name'] if columns else 'id')
-                
-                results.append({
-                    'id': record['id'],
-                    'data': data,
-                    'display': data.get(display_field, str(record['id']))
-                })
-            
+                data = json.loads(record["record_data"])
+                display_field = display_column or next(
+                    (col["column_name"] for col in columns if col["is_display_field"]),
+                    columns[0]["column_name"] if columns else "id",
+                )
+
+                results.append(
+                    {
+                        "id": record["id"],
+                        "data": data,
+                        "display": data.get(display_field, str(record["id"])),
+                    }
+                )
+
             return results, "Search completed successfully"
-            
+
     except Exception as e:
         return [], f"Error searching data table: {str(e)}"
 
+
+def get_data_table_columns(table_id):
+    """Retrieve column definitions for a data table."""
+    try:
+        with get_enhanced_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT column_name, display_name, data_type, is_key_field,
+                       is_display_field, is_searchable
+                FROM data_table_columns
+                WHERE table_id = ?
+                ORDER BY id
+            """,
+                (table_id,),
+            )
+
+            columns = cursor.fetchall()
+            return [dict(col) for col in columns], "Columns retrieved"
+
+    except Exception as e:
+        return [], f"Error retrieving columns: {str(e)}"
+
+
 # Enhanced Template Management
+
 
 def create_enhanced_template(name, description, category, fields, created_by="admin"):
     """Create an enhanced case template with interactive fields."""
@@ -142,169 +190,212 @@ def create_enhanced_template(name, description, category, fields, created_by="ad
         with get_enhanced_db_connection() as conn:
             cursor = conn.cursor()
             current_time = datetime.now().isoformat()
-            
+
             # Create template
             template_config = {
-                'layout': 'default',
-                'validation': 'client_server',
-                'save_mode': 'auto',
-                'theme': 'default'
+                "layout": "default",
+                "validation": "client_server",
+                "save_mode": "auto",
+                "theme": "default",
             }
-            
-            cursor.execute('''
+
+            cursor.execute(
+                """
                 INSERT INTO enhanced_case_templates 
                 (name, description, category, template_config, created_at, created_by)
                 VALUES (?, ?, ?, ?, ?, ?)
-            ''', (name, description, category, json.dumps(template_config), current_time, created_by))
-            
+            """,
+                (
+                    name,
+                    description,
+                    category,
+                    json.dumps(template_config),
+                    current_time,
+                    created_by,
+                ),
+            )
+
             template_id = cursor.lastrowid
-            
+
             # Create fields
             for order, field in enumerate(fields):
-                cursor.execute('''
+                cursor.execute(
+                    """
                     INSERT INTO template_fields 
                     (template_id, field_id, field_name, field_type, is_required, display_order, 
                      field_config, validation_rules, conditional_logic, data_table_id, parent_field_id, created_at)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ''', (
-                    template_id,
-                    field['field_id'],
-                    field['field_name'],
-                    field['field_type'],
-                    field.get('is_required', 0),
-                    order,
-                    json.dumps(field.get('config', {})),
-                    json.dumps(field.get('validation_rules', {})),
-                    json.dumps(field.get('conditional_logic', {})),
-                    field.get('data_table_id'),
-                    field.get('parent_field_id'),
-                    current_time
-                ))
-                
+                """,
+                    (
+                        template_id,
+                        field["field_id"],
+                        field["field_name"],
+                        field["field_type"],
+                        field.get("is_required", 0),
+                        order,
+                        json.dumps(field.get("config", {})),
+                        json.dumps(field.get("validation_rules", {})),
+                        json.dumps(field.get("conditional_logic", {})),
+                        field.get("data_table_id"),
+                        field.get("parent_field_id"),
+                        current_time,
+                    ),
+                )
+
                 field_record_id = cursor.lastrowid
-                
+
                 # Create field dependencies if specified
-                if 'dependencies' in field:
-                    for dep in field['dependencies']:
-                        cursor.execute('''
+                if "dependencies" in field:
+                    for dep in field["dependencies"]:
+                        cursor.execute(
+                            """
                             INSERT INTO field_dependencies 
                             (dependent_field_id, parent_field_id, condition_type, condition_value, 
                              action_type, action_config, created_at)
                             VALUES (?, ?, ?, ?, ?, ?, ?)
-                        ''', (
-                            field_record_id,
-                            dep['parent_field_id'],
-                            dep['condition_type'],
-                            dep.get('condition_value'),
-                            dep['action_type'],
-                            json.dumps(dep.get('action_config', {})),
-                            current_time
-                        ))
-            
+                        """,
+                            (
+                                field_record_id,
+                                dep["parent_field_id"],
+                                dep["condition_type"],
+                                dep.get("condition_value"),
+                                dep["action_type"],
+                                json.dumps(dep.get("action_config", {})),
+                                current_time,
+                            ),
+                        )
+
             conn.commit()
             return template_id, "Enhanced template created successfully"
-            
+
     except Exception as e:
         return None, f"Error creating enhanced template: {str(e)}"
+
 
 def get_template_with_fields(template_id):
     """Get complete template with all fields and dependencies."""
     try:
         with get_enhanced_db_connection() as conn:
             cursor = conn.cursor()
-            
+
             # Get template
-            cursor.execute('''
+            cursor.execute(
+                """
                 SELECT * FROM enhanced_case_templates WHERE id = ?
-            ''', (template_id,))
+            """,
+                (template_id,),
+            )
             template = cursor.fetchone()
-            
+
             if not template:
                 return None, "Template not found"
-            
+
             # Get fields
-            cursor.execute('''
+            cursor.execute(
+                """
                 SELECT tf.*, dt.table_name as data_table_name
                 FROM template_fields tf
                 LEFT JOIN data_tables dt ON tf.data_table_id = dt.id
                 WHERE tf.template_id = ?
                 ORDER BY tf.display_order
-            ''', (template_id,))
+            """,
+                (template_id,),
+            )
             fields = cursor.fetchall()
-            
+
             # Get dependencies for each field
             field_dependencies = {}
             for field in fields:
-                cursor.execute('''
+                cursor.execute(
+                    """
                     SELECT fd.*, pf.field_id as parent_field_name
                     FROM field_dependencies fd
                     JOIN template_fields pf ON fd.parent_field_id = pf.id
                     WHERE fd.dependent_field_id = ?
-                ''', (field['id'],))
+                """,
+                    (field["id"],),
+                )
                 dependencies = cursor.fetchall()
-                field_dependencies[field['id']] = [dict(dep) for dep in dependencies]
-            
+                field_dependencies[field["id"]] = [dict(dep) for dep in dependencies]
+
             # Format result
             result = {
-                'template': dict(template),
-                'fields': [dict(field) for field in fields],
-                'dependencies': field_dependencies
+                "template": dict(template),
+                "fields": [dict(field) for field in fields],
+                "dependencies": field_dependencies,
             }
-            
+
             return result, "Template retrieved successfully"
-            
+
     except Exception as e:
         return None, f"Error retrieving template: {str(e)}"
 
+
 # Case Management
 
-def create_enhanced_case(template_id, title, description, case_data, created_by="admin", **kwargs):
+
+def create_enhanced_case(
+    template_id, title, description, case_data, created_by="admin", **kwargs
+):
     """Create an enhanced case instance."""
     try:
         with get_enhanced_db_connection() as conn:
             cursor = conn.cursor()
             current_time = datetime.now().isoformat()
-            
+
             # Generate case number
-            cursor.execute('SELECT COUNT(*) FROM enhanced_cases')
+            cursor.execute("SELECT COUNT(*) FROM enhanced_cases")
             case_count = cursor.fetchone()[0]
             case_number = f"CASE-{case_count + 1:06d}"
-            
-            cursor.execute('''
+
+            cursor.execute(
+                """
                 INSERT INTO enhanced_cases 
                 (case_number, template_id, title, description, status, priority, 
                  assigned_to, case_data, metadata, tags, due_date, created_at, created_by)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ''', (
-                case_number,
-                template_id,
-                title,
-                description,
-                kwargs.get('status', 'draft'),
-                kwargs.get('priority', 'medium'),
-                kwargs.get('assigned_to'),
-                json.dumps(case_data),
-                json.dumps(kwargs.get('metadata', {})),
-                kwargs.get('tags', ''),
-                kwargs.get('due_date'),
-                current_time,
-                created_by
-            ))
-            
+            """,
+                (
+                    case_number,
+                    template_id,
+                    title,
+                    description,
+                    kwargs.get("status", "draft"),
+                    kwargs.get("priority", "medium"),
+                    kwargs.get("assigned_to"),
+                    json.dumps(case_data),
+                    json.dumps(kwargs.get("metadata", {})),
+                    kwargs.get("tags", ""),
+                    kwargs.get("due_date"),
+                    current_time,
+                    created_by,
+                ),
+            )
+
             case_id = cursor.lastrowid
-            
+
             # Create history entry
-            cursor.execute('''
+            cursor.execute(
+                """
                 INSERT INTO case_history 
                 (case_id, action_type, comment, created_at, created_by)
                 VALUES (?, ?, ?, ?, ?)
-            ''', (case_id, 'created', f'Case {case_number} created', current_time, created_by))
-            
+            """,
+                (
+                    case_id,
+                    "created",
+                    f"Case {case_number} created",
+                    current_time,
+                    created_by,
+                ),
+            )
+
             conn.commit()
             return case_id, case_number, "Case created successfully"
-            
+
     except Exception as e:
         return None, None, f"Error creating case: {str(e)}"
+
 
 def update_case_field(case_id, field_name, old_value, new_value, updated_by="admin"):
     """Update a specific field in a case and log the change."""
@@ -312,81 +403,100 @@ def update_case_field(case_id, field_name, old_value, new_value, updated_by="adm
         with get_enhanced_db_connection() as conn:
             cursor = conn.cursor()
             current_time = datetime.now().isoformat()
-            
+
             # Get current case data
-            cursor.execute('SELECT case_data FROM enhanced_cases WHERE id = ?', (case_id,))
+            cursor.execute(
+                "SELECT case_data FROM enhanced_cases WHERE id = ?", (case_id,)
+            )
             case = cursor.fetchone()
-            
+
             if not case:
                 return False, "Case not found"
-            
-            case_data = json.loads(case['case_data'])
+
+            case_data = json.loads(case["case_data"])
             case_data[field_name] = new_value
-            
+
             # Update case
-            cursor.execute('''
+            cursor.execute(
+                """
                 UPDATE enhanced_cases 
                 SET case_data = ?, updated_at = ?, last_modified_by = ?
                 WHERE id = ?
-            ''', (json.dumps(case_data), current_time, updated_by, case_id))
-            
+            """,
+                (json.dumps(case_data), current_time, updated_by, case_id),
+            )
+
             # Log change
-            cursor.execute('''
+            cursor.execute(
+                """
                 INSERT INTO case_history 
                 (case_id, action_type, field_name, old_value, new_value, created_at, created_by)
                 VALUES (?, ?, ?, ?, ?, ?, ?)
-            ''', (case_id, 'field_changed', field_name, str(old_value), str(new_value), current_time, updated_by))
-            
+            """,
+                (
+                    case_id,
+                    "field_changed",
+                    field_name,
+                    str(old_value),
+                    str(new_value),
+                    current_time,
+                    updated_by,
+                ),
+            )
+
             conn.commit()
             return True, "Field updated successfully"
-            
+
     except Exception as e:
         return False, f"Error updating field: {str(e)}"
+
 
 def get_cases_list(status=None, assigned_to=None, template_id=None, limit=50, offset=0):
     """Get a list of cases with optional filtering."""
     try:
         with get_enhanced_db_connection() as conn:
             cursor = conn.cursor()
-            
-            query = '''
+
+            query = """
                 SELECT ec.*, ect.name as template_name
                 FROM enhanced_cases ec
                 JOIN enhanced_case_templates ect ON ec.template_id = ect.id
                 WHERE 1=1
-            '''
+            """
             params = []
-            
+
             if status:
-                query += ' AND ec.status = ?'
+                query += " AND ec.status = ?"
                 params.append(status)
-            
+
             if assigned_to:
-                query += ' AND ec.assigned_to = ?'
+                query += " AND ec.assigned_to = ?"
                 params.append(assigned_to)
-            
+
             if template_id:
-                query += ' AND ec.template_id = ?'
+                query += " AND ec.template_id = ?"
                 params.append(template_id)
-            
-            query += ' ORDER BY ec.created_at DESC LIMIT ? OFFSET ?'
+
+            query += " ORDER BY ec.created_at DESC LIMIT ? OFFSET ?"
             params.extend([limit, offset])
-            
+
             cursor.execute(query, params)
             cases = cursor.fetchall()
-            
+
             return [dict(case) for case in cases], "Cases retrieved successfully"
-            
+
     except Exception as e:
         return [], f"Error retrieving cases: {str(e)}"
+
 
 def get_data_tables_list():
     """Get list of all available data tables."""
     try:
         with get_enhanced_db_connection() as conn:
             cursor = conn.cursor()
-            
-            cursor.execute('''
+
+            cursor.execute(
+                """
                 SELECT dt.*, 
                        COUNT(dtr.id) as record_count,
                        GROUP_CONCAT(dtc.display_name) as columns
@@ -396,37 +506,45 @@ def get_data_tables_list():
                 WHERE dt.is_active = 1
                 GROUP BY dt.id
                 ORDER BY dt.display_name
-            ''')
-            
+            """
+            )
+
             tables = cursor.fetchall()
-            return [dict(table) for table in tables], "Data tables retrieved successfully"
-            
+            return [
+                dict(table) for table in tables
+            ], "Data tables retrieved successfully"
+
     except Exception as e:
         return [], f"Error retrieving data tables: {str(e)}"
+
 
 def get_templates_list():
     """Get list of all enhanced templates."""
     try:
         with get_enhanced_db_connection() as conn:
             cursor = conn.cursor()
-            
-            cursor.execute('''
+
+            cursor.execute(
+                """
                 SELECT ect.*, 
                        COUNT(tf.id) as field_count
                 FROM enhanced_case_templates ect
                 LEFT JOIN template_fields tf ON ect.id = tf.template_id
                 GROUP BY ect.id
                 ORDER BY ect.created_at DESC
-            ''')
-            
+            """
+            )
+
             templates = cursor.fetchall()
             return [dict(template) for template in templates]
-            
+
     except Exception as e:
         print(f"Error retrieving templates: {str(e)}")
         return []
 
+
 # Utility Functions
+
 
 def validate_field_dependencies(template_id, case_data):
     """Validate field dependencies for a case."""
@@ -434,162 +552,254 @@ def validate_field_dependencies(template_id, case_data):
         template_data, msg = get_template_with_fields(template_id)
         if not template_data:
             return False, msg
-        
+
         errors = []
-        
-        for field in template_data['fields']:
-            field_id = field['field_id']
+
+        for field in template_data["fields"]:
+            field_id = field["field_id"]
             field_value = case_data.get(field_id)
-            
+
             # Check dependencies
-            if field['id'] in template_data['dependencies']:
-                for dep in template_data['dependencies'][field['id']]:
-                    parent_value = case_data.get(dep['parent_field_name'])
-                    
+            if field["id"] in template_data["dependencies"]:
+                for dep in template_data["dependencies"][field["id"]]:
+                    parent_value = case_data.get(dep["parent_field_name"])
+
                     # Evaluate condition
                     condition_met = evaluate_condition(
-                        parent_value, 
-                        dep['condition_type'], 
-                        dep.get('condition_value')
+                        parent_value, dep["condition_type"], dep.get("condition_value")
                     )
-                    
+
                     # Apply action if condition is met
                     if condition_met:
-                        action_config = json.loads(dep.get('action_config', '{}'))
-                        
-                        if dep['action_type'] == 'require' and not field_value:
+                        action_config = json.loads(dep.get("action_config", "{}"))
+
+                        if dep["action_type"] == "require" and not field_value:
                             errors.append(f"Field '{field['field_name']}' is required")
-                        elif dep['action_type'] == 'set_value':
-                            case_data[field_id] = action_config.get('value')
-        
+                        elif dep["action_type"] == "set_value":
+                            case_data[field_id] = action_config.get("value")
+
         return len(errors) == 0, errors if errors else "Validation passed"
-        
+
     except Exception as e:
         return False, f"Error validating dependencies: {str(e)}"
 
+
 def evaluate_condition(value, condition_type, condition_value):
     """Evaluate a dependency condition."""
-    if condition_type == 'equals':
+    if condition_type == "equals":
         return str(value) == str(condition_value)
-    elif condition_type == 'not_equals':
+    elif condition_type == "not_equals":
         return str(value) != str(condition_value)
-    elif condition_type == 'contains':
+    elif condition_type == "contains":
         return condition_value in str(value)
-    elif condition_type == 'not_contains':
+    elif condition_type == "not_contains":
         return condition_value not in str(value)
-    elif condition_type == 'is_empty':
-        return not value or str(value).strip() == ''
-    elif condition_type == 'is_not_empty':
-        return value and str(value).strip() != ''
-    elif condition_type == 'in_list':
-        return str(value) in condition_value.split(',')
-    elif condition_type == 'not_in_list':
-        return str(value) not in condition_value.split(',')
-    
+    elif condition_type == "is_empty":
+        return not value or str(value).strip() == ""
+    elif condition_type == "is_not_empty":
+        return value and str(value).strip() != ""
+    elif condition_type == "in_list":
+        return str(value) in condition_value.split(",")
+    elif condition_type == "not_in_list":
+        return str(value) not in condition_value.split(",")
+
     return False
+
 
 def get_field_options_for_dependency(parent_field_id, parent_value):
     """Get dynamic options for a dependent field based on parent value."""
     try:
         with get_enhanced_db_connection() as conn:
             cursor = conn.cursor()
-            
+
             # Get the field configuration
-            cursor.execute('''
+            cursor.execute(
+                """
                 SELECT field_config, data_table_id 
                 FROM template_fields 
                 WHERE id = ?
-            ''', (parent_field_id,))
-            
+            """,
+                (parent_field_id,),
+            )
+
             field = cursor.fetchone()
             if not field:
                 return [], "Field not found"
-            
-            config = json.loads(field['field_config'])
-            
+
+            config = json.loads(field["field_config"])
+
             # If it's connected to a data table, filter by parent value
-            if field['data_table_id']:
-                results, msg = search_data_table(field['data_table_id'], parent_value)
+            if field["data_table_id"]:
+                results, msg = search_data_table(field["data_table_id"], parent_value)
                 return results, msg
-            
+
             # Otherwise use static options from config
-            options_map = config.get('optionsMap', {})
+            options_map = config.get("optionsMap", {})
             return options_map.get(str(parent_value), []), "Options retrieved"
-            
+
     except Exception as e:
         return [], f"Error getting field options: {str(e)}"
+
 
 def delete_enhanced_template(template_id):
     """Delete an enhanced template if no cases reference it."""
     try:
         with get_enhanced_db_connection() as conn:
             cursor = conn.cursor()
-            cursor.execute('SELECT COUNT(*) FROM enhanced_cases WHERE template_id = ?', (template_id,))
+            cursor.execute(
+                "SELECT COUNT(*) FROM enhanced_cases WHERE template_id = ?",
+                (template_id,),
+            )
             if cursor.fetchone()[0] > 0:
                 return False, "Template is in use by existing cases"
-            cursor.execute('DELETE FROM enhanced_case_templates WHERE id = ?', (template_id,))
+            cursor.execute(
+                "DELETE FROM enhanced_case_templates WHERE id = ?", (template_id,)
+            )
             conn.commit()
             return True, "Template deleted successfully"
     except Exception as e:
         return False, f"Error deleting template: {str(e)}"
 
 
-def update_enhanced_template(template_id, name, description, category, fields, updated_by="admin"):
+def update_enhanced_template(
+    template_id, name, description, category, fields, updated_by="admin"
+):
     """Update an existing enhanced template with new metadata and fields."""
     try:
         with get_enhanced_db_connection() as conn:
             cursor = conn.cursor()
             current_time = datetime.now().isoformat()
 
-            cursor.execute('''
+            cursor.execute(
+                """
                 UPDATE enhanced_case_templates
                 SET name = ?, description = ?, category = ?, updated_at = ?
                 WHERE id = ?
-            ''', (name, description, category, current_time, template_id))
+            """,
+                (name, description, category, current_time, template_id),
+            )
 
-            cursor.execute('DELETE FROM template_fields WHERE template_id = ?', (template_id,))
+            cursor.execute(
+                "DELETE FROM template_fields WHERE template_id = ?", (template_id,)
+            )
 
             for order, field in enumerate(fields):
-                cursor.execute('''
+                cursor.execute(
+                    """
                     INSERT INTO template_fields
                     (template_id, field_id, field_name, field_type, is_required,
                      display_order, field_config, validation_rules, conditional_logic,
                      data_table_id, parent_field_id, created_at)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ''', (
-                    template_id,
-                    field['field_id'],
-                    field['field_name'],
-                    field['field_type'],
-                    field.get('is_required', 0),
-                    order,
-                    json.dumps(field.get('config', {})),
-                    json.dumps(field.get('validation_rules', {})),
-                    json.dumps(field.get('conditional_logic', {})),
-                    field.get('data_table_id'),
-                    field.get('parent_field_id'),
-                    current_time
-                ))
+                """,
+                    (
+                        template_id,
+                        field["field_id"],
+                        field["field_name"],
+                        field["field_type"],
+                        field.get("is_required", 0),
+                        order,
+                        json.dumps(field.get("config", {})),
+                        json.dumps(field.get("validation_rules", {})),
+                        json.dumps(field.get("conditional_logic", {})),
+                        field.get("data_table_id"),
+                        field.get("parent_field_id"),
+                        current_time,
+                    ),
+                )
 
                 field_record_id = cursor.lastrowid
-                if 'dependencies' in field:
-                    for dep in field['dependencies']:
-                        cursor.execute('''
+                if "dependencies" in field:
+                    for dep in field["dependencies"]:
+                        cursor.execute(
+                            """
                             INSERT INTO field_dependencies
                             (dependent_field_id, parent_field_id, condition_type, condition_value,
                              action_type, action_config, created_at)
                             VALUES (?, ?, ?, ?, ?, ?, ?)
-                        ''', (
-                            field_record_id,
-                            dep['parent_field_id'],
-                            dep['condition_type'],
-                            dep.get('condition_value'),
-                            dep['action_type'],
-                            json.dumps(dep.get('action_config', {})),
-                            current_time
-                        ))
+                        """,
+                            (
+                                field_record_id,
+                                dep["parent_field_id"],
+                                dep["condition_type"],
+                                dep.get("condition_value"),
+                                dep["action_type"],
+                                json.dumps(dep.get("action_config", {})),
+                                current_time,
+                            ),
+                        )
 
             conn.commit()
             return True, "Template updated successfully"
     except Exception as e:
         return False, f"Error updating template: {str(e)}"
+
+
+def delete_data_table(table_id):
+    """Delete a data table if not referenced by any template fields."""
+    try:
+        with get_enhanced_db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT COUNT(*) FROM template_fields WHERE data_table_id = ?",
+                (table_id,),
+            )
+            if cursor.fetchone()[0] > 0:
+                return False, "Data table is referenced by templates"
+
+            cursor.execute(
+                "UPDATE data_tables SET is_active = 0 WHERE id = ?", (table_id,)
+            )
+            conn.commit()
+            return True, "Data table deleted"
+    except Exception as e:
+        return False, f"Error deleting data table: {str(e)}"
+
+
+def update_data_table(
+    table_id, table_name, display_name, description, columns, updated_by="admin"
+):
+    """Update a data table definition and its columns."""
+    try:
+        with get_enhanced_db_connection() as conn:
+            cursor = conn.cursor()
+            current_time = datetime.now().isoformat()
+
+            cursor.execute(
+                """
+                UPDATE data_tables
+                SET table_name = ?, display_name = ?, description = ?, updated_at = ?
+                WHERE id = ?
+            """,
+                (table_name, display_name, description, current_time, table_id),
+            )
+
+            cursor.execute(
+                "DELETE FROM data_table_columns WHERE table_id = ?", (table_id,)
+            )
+
+            for column in columns:
+                cursor.execute(
+                    """
+                    INSERT INTO data_table_columns
+                    (table_id, column_name, display_name, data_type, is_key_field,
+                     is_display_field, is_searchable, validation_rules, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                    (
+                        table_id,
+                        column["column_name"],
+                        column["display_name"],
+                        column["data_type"],
+                        column.get("is_key_field", 0),
+                        column.get("is_display_field", 0),
+                        column.get("is_searchable", 1),
+                        json.dumps(column.get("validation_rules", {})),
+                        current_time,
+                    ),
+                )
+
+            conn.commit()
+            return True, "Data table updated"
+    except Exception as e:
+        return False, f"Error updating data table: {str(e)}"

--- a/enhanced_routes.py
+++ b/enhanced_routes.py
@@ -3,412 +3,532 @@ Enhanced case management routes for the Flask application.
 Handles template creation, case management, and data table operations.
 """
 
-from flask import Blueprint, render_template, request, jsonify, session, redirect, url_for
+from flask import (
+    Blueprint,
+    render_template,
+    request,
+    jsonify,
+    session,
+    redirect,
+    url_for,
+)
 import json
 from enhanced_db_utils import (
-    create_enhanced_template, get_template_with_fields, create_enhanced_case,
-    update_case_field, get_cases_list, create_data_table, add_data_table_record,
-    search_data_table, get_data_tables_list, validate_field_dependencies,
-    get_field_options_for_dependency, get_templates_list,
-    delete_enhanced_template, update_enhanced_template
+    create_enhanced_template,
+    get_template_with_fields,
+    create_enhanced_case,
+    update_case_field,
+    get_cases_list,
+    create_data_table,
+    add_data_table_record,
+    search_data_table,
+    get_data_tables_list,
+    validate_field_dependencies,
+    get_field_options_for_dependency,
+    get_templates_list,
+    delete_enhanced_template,
+    update_enhanced_template,
+    get_data_table_columns,
+    delete_data_table,
+    update_data_table,
 )
 
-enhanced_bp = Blueprint('enhanced', __name__, url_prefix='/enhanced')
+enhanced_bp = Blueprint("enhanced", __name__, url_prefix="/enhanced")
 
-@enhanced_bp.route('/template-builder')
+
+@enhanced_bp.route("/template-builder")
 def template_builder():
     """Show the enhanced template builder interface."""
-    if 'username' not in session:
-        return redirect(url_for('login'))
-    
-    return render_template('enhanced_template_editor.html')
+    if "username" not in session:
+        return redirect(url_for("login"))
+
+    return render_template("enhanced_template_editor.html")
 
 
-@enhanced_bp.route('/template/<int:template_id>/preview')
+@enhanced_bp.route("/template/<int:template_id>/preview")
 def preview_template(template_id):
     """Preview a template with its fields displayed read-only."""
-    if 'username' not in session:
-        return redirect(url_for('login'))
+    if "username" not in session:
+        return redirect(url_for("login"))
 
     template_data, message = get_template_with_fields(template_id)
     if not template_data:
         return message, 404
 
-    return render_template('enhanced_template_preview.html', template=template_data)
+    return render_template("enhanced_template_preview.html", template=template_data)
 
 
-@enhanced_bp.route('/template/<int:template_id>/edit')
+@enhanced_bp.route("/template/<int:template_id>/edit")
 def edit_template(template_id):
     """Edit an existing template using the builder."""
-    if 'username' not in session:
-        return redirect(url_for('login'))
+    if "username" not in session:
+        return redirect(url_for("login"))
 
     template_data, message = get_template_with_fields(template_id)
     if not template_data:
         return message, 404
 
-    return render_template('enhanced_template_editor.html', existing_template=template_data)
+    return render_template(
+        "enhanced_template_editor.html", existing_template=template_data
+    )
 
-@enhanced_bp.route('/templates')
+
+@enhanced_bp.route("/templates")
 def templates_list():
     """Show list of enhanced templates."""
-    if 'username' not in session:
-        return redirect(url_for('login'))
-    
+    if "username" not in session:
+        return redirect(url_for("login"))
+
     # Get templates from database
     templates = get_templates_list()
-    
-    return render_template('enhanced_templates_list.html', templates=templates)
 
-@enhanced_bp.route('/cases')
+    return render_template("enhanced_templates_list.html", templates=templates)
+
+
+@enhanced_bp.route("/cases")
 def cases_list():
     """Show list of enhanced cases."""
-    if 'username' not in session:
-        return redirect(url_for('login'))
-    
+    if "username" not in session:
+        return redirect(url_for("login"))
+
     # Get filter parameters
-    status = request.args.get('status')
-    assigned_to = request.args.get('assigned_to')
-    template_id = request.args.get('template_id')
-    page = int(request.args.get('page', 1))
-    per_page = int(request.args.get('per_page', 20))
-    
+    status = request.args.get("status")
+    assigned_to = request.args.get("assigned_to")
+    template_id = request.args.get("template_id")
+    page = int(request.args.get("page", 1))
+    per_page = int(request.args.get("per_page", 20))
+
     offset = (page - 1) * per_page
     cases, message = get_cases_list(status, assigned_to, template_id, per_page, offset)
     templates = get_templates_list()
-    
-    return render_template('enhanced_cases_list.html', 
-                         cases=cases, 
-                         templates=templates,
-                         current_page=page,
-                         per_page=per_page)
 
-@enhanced_bp.route('/case/<int:case_id>')
+    return render_template(
+        "enhanced_cases_list.html",
+        cases=cases,
+        templates=templates,
+        current_page=page,
+        per_page=per_page,
+    )
+
+
+@enhanced_bp.route("/case/<int:case_id>")
 def view_case(case_id):
     """View a specific case."""
-    if 'username' not in session:
-        return redirect(url_for('login'))
-    
+    if "username" not in session:
+        return redirect(url_for("login"))
+
     # Get case details
     # This would need to be implemented
     case_data = {}
-    
-    return render_template('enhanced_case_view.html', case=case_data)
 
-@enhanced_bp.route('/case/new/<int:template_id>')
+    return render_template("enhanced_case_view.html", case=case_data)
+
+
+@enhanced_bp.route("/case/new/<int:template_id>")
 def new_case(template_id):
     """Create a new case from a template."""
-    if 'username' not in session:
-        return redirect(url_for('login'))
-    
-    template_data, message = get_template_with_fields(template_id)
-    
-    if not template_data:
-        return jsonify({'error': message}), 404
-    
-    return render_template('enhanced_case_form.html', template=template_data)
+    if "username" not in session:
+        return redirect(url_for("login"))
 
-@enhanced_bp.route('/data-tables')
+    template_data, message = get_template_with_fields(template_id)
+
+    if not template_data:
+        return jsonify({"error": message}), 404
+
+    return render_template("enhanced_case_form.html", template=template_data)
+
+
+@enhanced_bp.route("/data-tables")
 def data_tables():
     """Manage data tables."""
-    if 'username' not in session:
-        return redirect(url_for('login'))
-    
+    if "username" not in session:
+        return redirect(url_for("login"))
+
     tables, message = get_data_tables_list()
-    
-    return render_template('enhanced_data_tables.html', tables=tables)
+
+    return render_template("enhanced_data_tables.html", tables=tables)
+
 
 # API Routes
 
-@enhanced_bp.route('/api/templates/create', methods=['POST'])
+
+@enhanced_bp.route("/api/templates/create", methods=["POST"])
 def api_create_template():
     """API endpoint to create a new template."""
-    if 'username' not in session:
-        return jsonify({'success': False, 'message': 'Not authenticated'}), 401
-    
+    if "username" not in session:
+        return jsonify({"success": False, "message": "Not authenticated"}), 401
+
     try:
         data = request.get_json()
-        
-        if not data.get('name') or not data.get('fields'):
-            return jsonify({'success': False, 'message': 'Name and fields are required'}), 400
-        
-        template_id, message = create_enhanced_template(
-            name=data['name'],
-            description=data.get('description', ''),
-            category=data.get('category', 'General'),
-            fields=data['fields'],
-            created_by=session['username']
-        )
-        
-        if template_id:
-            return jsonify({
-                'success': True,
-                'message': 'Template created successfully',
-                'template_id': template_id
-            })
-        else:
-            return jsonify({'success': False, 'message': message}), 500
-            
-    except Exception as e:
-        return jsonify({'success': False, 'message': str(e)}), 500
 
-@enhanced_bp.route('/api/templates/<int:template_id>')
+        if not data.get("name") or not data.get("fields"):
+            return (
+                jsonify({"success": False, "message": "Name and fields are required"}),
+                400,
+            )
+
+        template_id, message = create_enhanced_template(
+            name=data["name"],
+            description=data.get("description", ""),
+            category=data.get("category", "General"),
+            fields=data["fields"],
+            created_by=session["username"],
+        )
+
+        if template_id:
+            return jsonify(
+                {
+                    "success": True,
+                    "message": "Template created successfully",
+                    "template_id": template_id,
+                }
+            )
+        else:
+            return jsonify({"success": False, "message": message}), 500
+
+    except Exception as e:
+        return jsonify({"success": False, "message": str(e)}), 500
+
+
+@enhanced_bp.route("/api/templates/<int:template_id>")
 def api_get_template(template_id):
     """API endpoint to get template details."""
-    if 'username' not in session:
-        return jsonify({'error': 'Not authenticated'}), 401
-    
+    if "username" not in session:
+        return jsonify({"error": "Not authenticated"}), 401
+
     template_data, message = get_template_with_fields(template_id)
-    
+
     if template_data:
-        return jsonify({'success': True, 'template': template_data})
+        return jsonify({"success": True, "template": template_data})
     else:
-        return jsonify({'success': False, 'message': message}), 404
+        return jsonify({"success": False, "message": message}), 404
 
 
-@enhanced_bp.route('/api/templates/<int:template_id>/delete', methods=['DELETE'])
+@enhanced_bp.route("/api/templates/<int:template_id>/delete", methods=["DELETE"])
 def api_delete_template(template_id):
     """API endpoint to delete a template."""
-    if 'username' not in session:
-        return jsonify({'success': False, 'message': 'Not authenticated'}), 401
+    if "username" not in session:
+        return jsonify({"success": False, "message": "Not authenticated"}), 401
 
     success, message = delete_enhanced_template(template_id)
     status = 200 if success else 400
-    return jsonify({'success': success, 'message': message}), status
+    return jsonify({"success": success, "message": message}), status
 
 
-@enhanced_bp.route('/api/templates/<int:template_id>/update', methods=['PUT'])
+@enhanced_bp.route("/api/templates/<int:template_id>/update", methods=["PUT"])
 def api_update_template(template_id):
     """API endpoint to update an existing template."""
-    if 'username' not in session:
-        return jsonify({'success': False, 'message': 'Not authenticated'}), 401
+    if "username" not in session:
+        return jsonify({"success": False, "message": "Not authenticated"}), 401
 
     data = request.get_json()
-    if not data or not data.get('name') or not data.get('fields'):
-        return jsonify({'success': False, 'message': 'Name and fields are required'}), 400
+    if not data or not data.get("name") or not data.get("fields"):
+        return (
+            jsonify({"success": False, "message": "Name and fields are required"}),
+            400,
+        )
 
     success, message = update_enhanced_template(
         template_id,
-        data['name'],
-        data.get('description', ''),
-        data.get('category', 'General'),
-        data['fields'],
-        session['username']
+        data["name"],
+        data.get("description", ""),
+        data.get("category", "General"),
+        data["fields"],
+        session["username"],
     )
 
     status = 200 if success else 400
-    return jsonify({'success': success, 'message': message}), status
+    return jsonify({"success": success, "message": message}), status
 
-@enhanced_bp.route('/api/cases/create', methods=['POST'])
+
+@enhanced_bp.route("/api/cases/create", methods=["POST"])
 def api_create_case():
     """API endpoint to create a new case."""
-    if 'username' not in session:
-        return jsonify({'success': False, 'message': 'Not authenticated'}), 401
-    
+    if "username" not in session:
+        return jsonify({"success": False, "message": "Not authenticated"}), 401
+
     try:
         data = request.get_json()
-        
-        template_id = data.get('template_id')
-        title = data.get('title')
-        description = data.get('description', '')
-        case_data = data.get('case_data', {})
-        
+
+        template_id = data.get("template_id")
+        title = data.get("title")
+        description = data.get("description", "")
+        case_data = data.get("case_data", {})
+
         if not template_id or not title:
-            return jsonify({'success': False, 'message': 'Template ID and title are required'}), 400
-        
+            return (
+                jsonify(
+                    {"success": False, "message": "Template ID and title are required"}
+                ),
+                400,
+            )
+
         # Validate field dependencies
-        is_valid, validation_message = validate_field_dependencies(template_id, case_data)
-        
+        is_valid, validation_message = validate_field_dependencies(
+            template_id, case_data
+        )
+
         if not is_valid:
-            return jsonify({'success': False, 'message': f'Validation failed: {validation_message}'}), 400
-        
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "message": f"Validation failed: {validation_message}",
+                    }
+                ),
+                400,
+            )
+
         case_id, case_number, message = create_enhanced_case(
             template_id=template_id,
             title=title,
             description=description,
             case_data=case_data,
-            created_by=session['username'],
-            status=data.get('status', 'draft'),
-            priority=data.get('priority', 'medium'),
-            assigned_to=data.get('assigned_to'),
-            tags=data.get('tags', ''),
-            due_date=data.get('due_date')
+            created_by=session["username"],
+            status=data.get("status", "draft"),
+            priority=data.get("priority", "medium"),
+            assigned_to=data.get("assigned_to"),
+            tags=data.get("tags", ""),
+            due_date=data.get("due_date"),
         )
-        
-        if case_id:
-            return jsonify({
-                'success': True,
-                'message': 'Case created successfully',
-                'case_id': case_id,
-                'case_number': case_number
-            })
-        else:
-            return jsonify({'success': False, 'message': message}), 500
-            
-    except Exception as e:
-        return jsonify({'success': False, 'message': str(e)}), 500
 
-@enhanced_bp.route('/api/cases/<int:case_id>/update-field', methods=['POST'])
+        if case_id:
+            return jsonify(
+                {
+                    "success": True,
+                    "message": "Case created successfully",
+                    "case_id": case_id,
+                    "case_number": case_number,
+                }
+            )
+        else:
+            return jsonify({"success": False, "message": message}), 500
+
+    except Exception as e:
+        return jsonify({"success": False, "message": str(e)}), 500
+
+
+@enhanced_bp.route("/api/cases/<int:case_id>/update-field", methods=["POST"])
 def api_update_case_field(case_id):
     """API endpoint to update a specific field in a case."""
-    if 'username' not in session:
-        return jsonify({'success': False, 'message': 'Not authenticated'}), 401
-    
+    if "username" not in session:
+        return jsonify({"success": False, "message": "Not authenticated"}), 401
+
     try:
         data = request.get_json()
-        
-        field_name = data.get('field_name')
-        old_value = data.get('old_value')
-        new_value = data.get('new_value')
-        
+
+        field_name = data.get("field_name")
+        old_value = data.get("old_value")
+        new_value = data.get("new_value")
+
         if not field_name:
-            return jsonify({'success': False, 'message': 'Field name is required'}), 400
-        
+            return jsonify({"success": False, "message": "Field name is required"}), 400
+
         success, message = update_case_field(
             case_id=case_id,
             field_name=field_name,
             old_value=old_value,
             new_value=new_value,
-            updated_by=session['username']
+            updated_by=session["username"],
         )
-        
-        return jsonify({'success': success, 'message': message})
-        
-    except Exception as e:
-        return jsonify({'success': False, 'message': str(e)}), 500
 
-@enhanced_bp.route('/api/data-tables')
+        return jsonify({"success": success, "message": message})
+
+    except Exception as e:
+        return jsonify({"success": False, "message": str(e)}), 500
+
+
+@enhanced_bp.route("/api/data-tables")
 def api_get_data_tables():
     """API endpoint to get list of data tables."""
-    if 'username' not in session:
-        return jsonify({'error': 'Not authenticated'}), 401
-    
-    tables, message = get_data_tables_list()
-    
-    return jsonify({
-        'success': True,
-        'tables': tables,
-        'message': message
-    })
+    if "username" not in session:
+        return jsonify({"error": "Not authenticated"}), 401
 
-@enhanced_bp.route('/api/data-tables/create', methods=['POST'])
+    tables, message = get_data_tables_list()
+
+    return jsonify({"success": True, "tables": tables, "message": message})
+
+
+@enhanced_bp.route("/api/data-tables/create", methods=["POST"])
 def api_create_data_table():
     """API endpoint to create a new data table."""
-    if 'username' not in session:
-        return jsonify({'success': False, 'message': 'Not authenticated'}), 401
-    
+    if "username" not in session:
+        return jsonify({"success": False, "message": "Not authenticated"}), 401
+
     try:
         data = request.get_json()
-        
-        table_name = data.get('table_name')
-        display_name = data.get('display_name')
-        description = data.get('description', '')
-        columns = data.get('columns', [])
-        
+
+        table_name = data.get("table_name")
+        display_name = data.get("display_name")
+        description = data.get("description", "")
+        columns = data.get("columns", [])
+
         if not table_name or not display_name or not columns:
-            return jsonify({'success': False, 'message': 'Table name, display name, and columns are required'}), 400
-        
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "message": "Table name, display name, and columns are required",
+                    }
+                ),
+                400,
+            )
+
         table_id, message = create_data_table(
             table_name=table_name,
             display_name=display_name,
             description=description,
             columns=columns,
-            created_by=session['username']
+            created_by=session["username"],
         )
-        
-        if table_id:
-            return jsonify({
-                'success': True,
-                'message': 'Data table created successfully',
-                'table_id': table_id
-            })
-        else:
-            return jsonify({'success': False, 'message': message}), 500
-            
-    except Exception as e:
-        return jsonify({'success': False, 'message': str(e)}), 500
 
-@enhanced_bp.route('/api/data-tables/<int:table_id>/records', methods=['POST'])
+        if table_id:
+            return jsonify(
+                {
+                    "success": True,
+                    "message": "Data table created successfully",
+                    "table_id": table_id,
+                }
+            )
+        else:
+            return jsonify({"success": False, "message": message}), 500
+
+    except Exception as e:
+        return jsonify({"success": False, "message": str(e)}), 500
+
+
+@enhanced_bp.route("/api/data-tables/<int:table_id>/records", methods=["POST"])
 def api_add_data_record(table_id):
     """API endpoint to add a record to a data table."""
-    if 'username' not in session:
-        return jsonify({'success': False, 'message': 'Not authenticated'}), 401
-    
+    if "username" not in session:
+        return jsonify({"success": False, "message": "Not authenticated"}), 401
+
     try:
         data = request.get_json()
-        record_data = data.get('record_data', {})
-        
-        if not record_data:
-            return jsonify({'success': False, 'message': 'Record data is required'}), 400
-        
-        record_id, message = add_data_table_record(
-            table_id=table_id,
-            record_data=record_data,
-            created_by=session['username']
-        )
-        
-        if record_id:
-            return jsonify({
-                'success': True,
-                'message': 'Record added successfully',
-                'record_id': record_id
-            })
-        else:
-            return jsonify({'success': False, 'message': message}), 500
-            
-    except Exception as e:
-        return jsonify({'success': False, 'message': str(e)}), 500
+        record_data = data.get("record_data", {})
 
-@enhanced_bp.route('/api/data-tables/<int:table_id>/search')
+        if not record_data:
+            return (
+                jsonify({"success": False, "message": "Record data is required"}),
+                400,
+            )
+
+        record_id, message = add_data_table_record(
+            table_id=table_id, record_data=record_data, created_by=session["username"]
+        )
+
+        if record_id:
+            return jsonify(
+                {
+                    "success": True,
+                    "message": "Record added successfully",
+                    "record_id": record_id,
+                }
+            )
+        else:
+            return jsonify({"success": False, "message": message}), 500
+
+    except Exception as e:
+        return jsonify({"success": False, "message": str(e)}), 500
+
+
+@enhanced_bp.route("/api/data-tables/<int:table_id>/search")
 def api_search_data_table(table_id):
     """API endpoint to search records in a data table."""
-    if 'username' not in session:
-        return jsonify({'error': 'Not authenticated'}), 401
-    
-    search_term = request.args.get('q', '')
-    limit = int(request.args.get('limit', 10))
-    
-    results, message = search_data_table(table_id, search_term, limit)
-    
-    return jsonify({
-        'success': True,
-        'results': results,
-        'message': message
-    })
+    if "username" not in session:
+        return jsonify({"error": "Not authenticated"}), 401
 
-@enhanced_bp.route('/api/fields/<int:field_id>/options')
+    search_term = request.args.get("q", "")
+    limit = int(request.args.get("limit", 10))
+
+    display_column = request.args.get("column")
+    results, message = search_data_table(table_id, search_term, limit, display_column)
+
+    return jsonify({"success": True, "results": results, "message": message})
+
+
+@enhanced_bp.route("/api/data-tables/<int:table_id>/columns")
+def api_get_table_columns(table_id):
+    """API endpoint to retrieve data table columns."""
+    if "username" not in session:
+        return jsonify({"error": "Not authenticated"}), 401
+
+    columns, message = get_data_table_columns(table_id)
+    status = 200 if columns else 404
+    return (
+        jsonify({"success": bool(columns), "columns": columns, "message": message}),
+        status,
+    )
+
+
+@enhanced_bp.route("/api/data-tables/<int:table_id>", methods=["DELETE"])
+def api_delete_data_table(table_id):
+    """API endpoint to delete a data table."""
+    if "username" not in session:
+        return jsonify({"success": False, "message": "Not authenticated"}), 401
+
+    success, message = delete_data_table(table_id)
+    status = 200 if success else 400
+    return jsonify({"success": success, "message": message}), status
+
+
+@enhanced_bp.route("/api/data-tables/<int:table_id>", methods=["PUT"])
+def api_update_data_table_route(table_id):
+    """API endpoint to update a data table."""
+    if "username" not in session:
+        return jsonify({"success": False, "message": "Not authenticated"}), 401
+
+    data = request.get_json()
+    if not data:
+        return jsonify({"success": False, "message": "No data provided"}), 400
+
+    success, message = update_data_table(
+        table_id,
+        data.get("table_name"),
+        data.get("display_name"),
+        data.get("description", ""),
+        data.get("columns", []),
+        session["username"],
+    )
+
+    status = 200 if success else 400
+    return jsonify({"success": success, "message": message}), status
+
+
+@enhanced_bp.route("/api/fields/<int:field_id>/options")
 def api_get_field_options(field_id):
     """API endpoint to get dynamic options for a dependent field."""
-    if 'username' not in session:
-        return jsonify({'error': 'Not authenticated'}), 401
-    
-    parent_value = request.args.get('parent_value', '')
-    
-    options, message = get_field_options_for_dependency(field_id, parent_value)
-    
-    return jsonify({
-        'success': True,
-        'options': options,
-        'message': message
-    })
+    if "username" not in session:
+        return jsonify({"error": "Not authenticated"}), 401
 
-@enhanced_bp.route('/api/templates/<int:template_id>/validate', methods=['POST'])
+    parent_value = request.args.get("parent_value", "")
+
+    options, message = get_field_options_for_dependency(field_id, parent_value)
+
+    return jsonify({"success": True, "options": options, "message": message})
+
+
+@enhanced_bp.route("/api/templates/<int:template_id>/validate", methods=["POST"])
 def api_validate_template_data(template_id):
     """API endpoint to validate case data against template rules."""
-    if 'username' not in session:
-        return jsonify({'success': False, 'message': 'Not authenticated'}), 401
-    
+    if "username" not in session:
+        return jsonify({"success": False, "message": "Not authenticated"}), 401
+
     try:
         data = request.get_json()
-        case_data = data.get('case_data', {})
-        
-        is_valid, validation_result = validate_field_dependencies(template_id, case_data)
-        
-        return jsonify({
-            'success': True,
-            'is_valid': is_valid,
-            'validation_result': validation_result
-        })
-        
+        case_data = data.get("case_data", {})
+
+        is_valid, validation_result = validate_field_dependencies(
+            template_id, case_data
+        )
+
+        return jsonify(
+            {
+                "success": True,
+                "is_valid": is_valid,
+                "validation_result": validation_result,
+            }
+        )
+
     except Exception as e:
-        return jsonify({'success': False, 'message': str(e)}), 500
+        return jsonify({"success": False, "message": str(e)}), 500

--- a/static/js/enhanced-case-form.js
+++ b/static/js/enhanced-case-form.js
@@ -61,13 +61,11 @@ function loadDataTableOptions(selectField, tableId) {
     selectField.classList.add('loading');
     selectField.disabled = true;
     
-    // Note: This would need to be updated to use the correct API endpoint
-    // For now, using a placeholder endpoint
-    fetch(`/enhanced/api/data-tables/${tableId}/records`)
+    fetch(`/enhanced/api/data-tables/${tableId}/search?q=&limit=100`)
         .then(response => response.json())
         .then(data => {
-            if (data.success && data.records) {
-                populateSelectOptions(selectField, data.records);
+            if (data.success && data.results) {
+                populateSelectOptions(selectField, data.results);
             } else {
                 console.error('Failed to load data table options:', data.message);
                 showFieldError(selectField, 'Failed to load options');

--- a/templates/enhanced_case_form.html
+++ b/templates/enhanced_case_form.html
@@ -57,25 +57,46 @@
                                           data-field-id="{{ field.field_id }}">{{ case.case_data[field.field_id] if case else '' }}</textarea>
                             
                             {% elif field.field_type == 'select' %}
-                                <select name="{{ field.field_id }}" 
-                                        class="form-select case-field" 
+                                {% if field.data_table_id %}
+                                <select name="{{ field.field_id }}"
+                                        class="form-select case-field data-table-lookup"
+                                        {% if field.is_required %}required{% endif %}
+                                        data-field-id="{{ field.field_id }}"
+                                        data-table-id="{{ field.data_table_id }}"
+                                        data-column="{{ config.dataColumn }}"
+                                        data-searchable="{{ config.searchable }}">
+                                    <option value="">Select from data table...</option>
+                                </select>
+                                {% else %}
+                                <select name="{{ field.field_id }}"
+                                        class="form-select case-field"
                                         {% if field.is_required %}required{% endif %}
                                         data-field-id="{{ field.field_id }}">
                                     <option value="">Select an option...</option>
                                     {% for option in config.options or [] %}
-                                    <option value="{{ option.value }}" 
+                                    <option value="{{ option.value }}"
                                             {% if case and case.case_data[field.field_id] == option.value %}selected{% endif %}>
                                         {{ option.label }}
                                     </option>
                                     {% endfor %}
                                 </select>
+                                {% endif %}
                             
                             {% elif field.field_type == 'radio' %}
+                                {% if field.data_table_id %}
+                                <div class="data-table-lookup"
+                                     data-lookup-type="radio"
+                                     data-field-name="{{ field.field_id }}"
+                                     data-field-id="{{ field.field_id }}"
+                                     data-table-id="{{ field.data_table_id }}"
+                                     data-column="{{ config.dataColumn }}"
+                                     {% if field.is_required %}data-required="true"{% endif %}></div>
+                                {% else %}
                                 {% for option in config.options or [] %}
                                 <div class="form-check">
-                                    <input class="form-check-input case-field" 
-                                           type="radio" 
-                                           name="{{ field.field_id }}" 
+                                    <input class="form-check-input case-field"
+                                           type="radio"
+                                           name="{{ field.field_id }}"
                                            id="{{ field.field_id }}_{{ loop.index }}"
                                            value="{{ option.value }}"
                                            {% if case and case.case_data[field.field_id] == option.value %}checked{% endif %}
@@ -86,13 +107,22 @@
                                     </label>
                                 </div>
                                 {% endfor %}
+                                {% endif %}
                             
                             {% elif field.field_type == 'checkbox' %}
+                                {% if field.data_table_id %}
+                                <div class="data-table-lookup"
+                                     data-lookup-type="checkbox"
+                                     data-field-name="{{ field.field_id }}[]"
+                                     data-field-id="{{ field.field_id }}"
+                                     data-table-id="{{ field.data_table_id }}"
+                                     data-column="{{ config.dataColumn }}"></div>
+                                {% else %}
                                 {% for option in config.options or [] %}
                                 <div class="form-check">
-                                    <input class="form-check-input case-field" 
-                                           type="checkbox" 
-                                           name="{{ field.field_id }}[]" 
+                                    <input class="form-check-input case-field"
+                                           type="checkbox"
+                                           name="{{ field.field_id }}[]"
                                            id="{{ field.field_id }}_{{ loop.index }}"
                                            value="{{ option.value }}"
                                            {% if case and option.value in (case.case_data[field.field_id] or '').split(',') %}checked{% endif %}
@@ -102,7 +132,17 @@
                                     </label>
                                 </div>
                                 {% endfor %}
-                            
+                                {% endif %}
+
+                            {% elif field.field_type == 'autocomplete' %}
+                                {% if field.data_table_id %}
+                                <input type="text" name="{{ field.field_id }}" class="form-control case-field data-table-lookup"
+                                       data-field-id="{{ field.field_id }}" data-table-id="{{ field.data_table_id }}" data-column="{{ config.dataColumn }}">
+                                {% else %}
+                                <input type="text" name="{{ field.field_id }}" class="form-control case-field"
+                                       value="{{ case.case_data[field.field_id] if case else '' }}">
+                                {% endif %}
+
                             {% elif field.field_type == 'date' %}
                                 <input type="date" 
                                        name="{{ field.field_id }}" 
@@ -130,16 +170,6 @@
                                 </small>
                                 {% endif %}
                             
-                            {% elif field.field_type == 'data_table_lookup' %}
-                                <select name="{{ field.field_id }}" 
-                                        class="form-select case-field data-table-lookup" 
-                                        {% if field.is_required %}required{% endif %}
-                                        data-field-id="{{ field.field_id }}"
-                                        data-table-id="{{ config.dataTableId }}"
-                                        data-searchable="{{ config.searchable }}">
-                                    <option value="">Select from data table...</option>
-                                    <!-- Options will be loaded via JavaScript -->
-                                </select>
                             
                             {% elif field.field_type == 'rating' %}
                                 <div class="rating-field" data-field-id="{{ field.field_id }}">

--- a/templates/enhanced_template_editor.html
+++ b/templates/enhanced_template_editor.html
@@ -1,12 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Enhanced Case Management - Template Editor</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css" rel="stylesheet">
-    <style>
+{% extends 'layout.html' %}
+{% block content %}
+<style>
         .field-type-icon {
             width: 20px;
             height: 20px;
@@ -149,9 +143,7 @@
         .drag-handle:active {
             cursor: grabbing;
         }
-    </style>
-</head>
-<body>
+</style>
     <div class="template-builder">
         <div class="container-fluid">
             <div class="builder-card">
@@ -211,10 +203,6 @@
                                 <div class="field-type-card" data-type="checkbox">
                                     <i class="bi bi-check-square"></i>
                                     <div class="mt-2">Checkboxes</div>
-                                </div>
-                                <div class="field-type-card" data-type="data_table_lookup">
-                                    <i class="bi bi-table"></i>
-                                    <div class="mt-2">Data Lookup</div>
                                 </div>
                                 <div class="field-type-card" data-type="dependent_field">
                                     <i class="bi bi-diagram-3"></i>
@@ -401,5 +389,4 @@
     <script>window.existingTemplate = {{ existing_template|tojson }};</script>
     {% endif %}
     <script src="/static/js/enhanced-template-editor.js"></script>
-</body>
-</html>
+{% endblock %}

--- a/templates/enhanced_template_editor.html
+++ b/templates/enhanced_template_editor.html
@@ -397,6 +397,9 @@
     <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+    {% if existing_template %}
+    <script>window.existingTemplate = {{ existing_template|tojson }};</script>
+    {% endif %}
     <script src="/static/js/enhanced-template-editor.js"></script>
 </body>
 </html>

--- a/templates/enhanced_template_preview.html
+++ b/templates/enhanced_template_preview.html
@@ -1,0 +1,54 @@
+{% extends "layout.html" %}
+
+{% block content %}
+<div class="container">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h2><i class="bi bi-eye"></i> {{ template.template.name }} Preview</h2>
+        <a href="/enhanced/templates" class="btn btn-outline-secondary">
+            <i class="bi bi-arrow-left"></i> Back
+        </a>
+    </div>
+    <form>
+    {% for field in template.fields %}
+        {% set config = field.field_config|from_json if field.field_config else {} %}
+        <div class="mb-3">
+            <label class="form-label">{{ field.field_name }}</label>
+            {% if field.field_type == 'text' %}
+                <input type="text" class="form-control" placeholder="{{ config.placeholder or '' }}" disabled>
+            {% elif field.field_type == 'textarea' %}
+                <textarea class="form-control" rows="{{ config.rows or 3 }}" placeholder="{{ config.placeholder or '' }}" disabled></textarea>
+            {% elif field.field_type == 'select' %}
+                <select class="form-select" disabled>
+                    <option>Select...</option>
+                    {% for option in config.options or [] %}
+                        <option>{{ option.label }}</option>
+                    {% endfor %}
+                </select>
+            {% elif field.field_type == 'radio' %}
+                {% for option in config.options or [] %}
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" disabled>
+                    <label class="form-check-label">{{ option.label }}</label>
+                </div>
+                {% endfor %}
+            {% elif field.field_type == 'checkbox' %}
+                {% for option in config.options or [] %}
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" disabled>
+                    <label class="form-check-label">{{ option.label }}</label>
+                </div>
+                {% endfor %}
+            {% elif field.field_type == 'date' %}
+                <input type="date" class="form-control" disabled>
+            {% elif field.field_type == 'data_table_lookup' %}
+                <select class="form-select" disabled>
+                    <option>Select...</option>
+                </select>
+            {% else %}
+                <input type="text" class="form-control" disabled>
+            {% endif %}
+        </div>
+    {% endfor %}
+    </form>
+</div>
+{% endblock %}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -29,9 +29,6 @@
               <li class="nav-item">
                 <a class="nav-link" href="/categories">Categories</a>
               </li>
-              <li class="nav-item">
-                <a class="nav-link" href="/cases">Cases</a>
-              </li>
               <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle" href="#" id="caseManagementDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                   <i class="bi bi-gear-fill"></i> Enhanced Cases
@@ -51,12 +48,6 @@
             <li class="nav-item">
               <a class="nav-link" href="/admin/external-tools">External Tools CFG</a>
             </li>
-              <li class="nav-item">
-                <a class="nav-link" href="/admin/data-tables">Data Tables</a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link" href="/admin/case-templates">Case Templates</a>
-              </li>
               <li class="nav-item">
                 <a class="nav-link" href="/manage-admins">Admin CFG</a>
               </li>


### PR DESCRIPTION
## Summary
- support deleting and updating enhanced templates in the DB
- expose preview, edit, update and delete template routes
- load data tables from the API in the template editor
- allow editing an existing template in the builder
- fetch case form options via the search endpoint
- remove legacy navigation links
- add HTML preview page for templates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d38884788321bdb5b8bce4706d35